### PR TITLE
Added singleton-documents, to limit frontpage to only be one document

### DIFF
--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -1,7 +1,28 @@
 import {defineConfig} from 'sanity'
-import {structureTool} from 'sanity/structure'
+import {StructureBuilder, StructureResolverContext, structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
+import { HomeIcon, DocumentTextIcon } from '@sanity/icons'
+
+//singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
+const singletonActions = new Set(["publish", "discardChanges", "restore"])
+const singletonTypes = new Set(["frontpage"])
+
+const deskStructure = ( S: StructureBuilder)  => S.list()
+  .title("Innhold")
+  .items([
+    S.listItem()
+    .title("Forside")
+    .id("frontpage")
+    .child(
+      S.document()
+      .schemaType("frontpage")
+      .documentId("frontpage")
+    ).icon(HomeIcon),
+    S.documentTypeListItem("article")
+    .title("Artikler")
+    .icon(DocumentTextIcon),
+  ])
 
 export default defineConfig({
   name: 'default',
@@ -10,9 +31,18 @@ export default defineConfig({
   projectId: process.env.SANITY_STUDIO_PROJECT_ID ?? '0chpibsu',
   dataset: process.env.SANITY_STUDIO_DATASET ?? 'production',
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [structureTool({ structure: deskStructure }), visionTool()],
 
   schema: {
     types: schemaTypes,
+    templates: (templates) =>
+      templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),
+  },
+  document: {
+    // filter out actions that should not be available for singleton pages
+    actions: (input, context) =>
+      singletonTypes.has(context.schemaType)
+        ? input.filter(({ action }) => action && singletonActions.has(action))
+        : input,
   },
 })


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.


## Linke til oppgave (Notion).
https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=f410f903d31941f2b7579f5177920827&pm=s

## Beskrivelse.
For at det kun skal være mulig å lage kun én forside har vi lagt til singleton document types i sanity.config.ts. For å få til dette måtte vi bruke structurebuilder, og bygge strukturen på sidemenyen manuelt. Her sier man hvilke typer som skal være singleton og hvilke actions de ikke skal ha tilgang til. Actions de ikke skal ha tilgang til er sletting, oppretting og duplisering.

OBS: det vil si at når vi legger til nye sider/sidetyper som vi ønsker at skal dukke opp i sidemenyen, så må vi legge det til i deskStructure i sanity.config.ts

OBS2: hvis man skal lage et singletondocument burde man lage det før man legge til typen i singletontypes, siden oppretting av dokument ikke er tilgjengelig på singleton-types.

La også til ikoner for forside og artikler.

Guiden jeg fulgte for å gjøre dette ligger her: https://www.sanity.io/guides/singleton-document

## Skjermbilder.

![image](https://github.com/Fjaereheia/fjaereheia/assets/31958950/40b69370-a81a-444a-a04f-1ca12196bc85)

