### PR TITLE
Language sanity

### DIFF
--- a/cms/createSingletons.ts
+++ b/cms/createSingletons.ts
@@ -1,0 +1,72 @@
+import {getCliClient} from 'sanity/cli'
+
+/**
+ * This script will create one or many "singleton" documents for each language
+ * It works by appending the language ID to the document ID
+ * and creating the translations.metadata document
+ *
+ * 1. Take a backup of your dataset with:
+ * `npx sanity@latest dataset export`
+ *
+ * 2. Copy this file to the root of your Sanity Studio project
+ *
+ * 3. Update the SINGLETONS and LANGUAGES constants to your needs
+ *
+ * 4. Run the script (replace <schema-type> with the name of your schema type):
+ * npx sanity@latest exec ./createSingletons.ts --with-user-token
+ *
+ * 5. Update your desk structure to use the new documents
+ */
+
+const SINGLETONS = [{id: 'frontpage', title: 'Forside', _type: 'frontpage'}]
+
+const LANGUAGES = [
+  {id: `nb`, title: `🇳🇴 Norwegian (Bokmål)`},
+  {id: `en`, title: `🇬🇧 English`},
+]
+
+// This will use the client configured in ./sanity.cli.ts
+const client = getCliClient()
+
+async function createSingletons() {
+  const documents = SINGLETONS.map((singleton) => {
+    const translations = LANGUAGES.map((language) => ({
+      _id: `${singleton.id}-${language.id}`,
+      _type: singleton._type,
+      language: language.id,
+    }))
+
+    const metadata = {
+      _id: `${singleton.id}-translation-metadata`,
+      _type: `translation.metadata`,
+      translations: translations.map((translation) => ({
+        _key: translation.language,
+        value: {
+          _type: 'reference',
+          _ref: translation._id,
+        },
+      })),
+      schemaTypes: Array.from(new Set(translations.map((translation) => translation._type))),
+    }
+
+    return [metadata, ...translations]
+  }).flat()
+
+  const transaction = client.transaction()
+
+  documents.forEach((doc) => {
+    transaction.createOrReplace(doc as any)
+  })
+
+  await transaction
+    .commit()
+    .then((res) => {
+      // eslint-disable-next-line no-console
+      console.log(res)
+    })
+    .catch((err) => {
+      console.error(err)
+    })
+}
+
+createSingletons()

--- a/cms/helperFunctions.ts
+++ b/cms/helperFunctions.ts
@@ -1,0 +1,23 @@
+import {SlugValidationContext} from 'sanity'
+
+export async function isUniqueOtherThanLanguage(slug: string, context: SlugValidationContext) {
+  const {document, getClient} = context
+  if (!document?.language) {
+    return true
+  }
+  const client = getClient({apiVersion: '2023-04-24'})
+  const id = document._id.replace(/^drafts\./, '')
+  const params = {
+    draft: `drafts.${id}`,
+    published: id,
+    language: document.language,
+    slug,
+  }
+  const query = `!defined(*[
+    !(_id in [$draft, $published]) &&
+    slug.current == $slug &&
+    language == $language
+  ][0]._id)`
+  const result = await client.fetch(query, params)
+  return result
+}

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@sanity/document-internationalization": "^3.0.0",
         "@sanity/vision": "^3.45.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3095,6 +3096,43 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sanity/document-internationalization": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/document-internationalization/-/document-internationalization-3.0.0.tgz",
+      "integrity": "sha512-HQQiix1MCNtXOLpi1ILjpT8EGk55Yv7515DVWcJAHLSjfpYAo9wvGfkZhRhP5lzWxLj2DsyeBX2zkF2J3QDs2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^2.11.7",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^2.1.0",
+        "@sanity/uuid": "^3.0.2",
+        "sanity-plugin-internationalized-array": "^2.0.0",
+        "sanity-plugin-utils": "^1.6.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@sanity/mutator": "^3.37.0",
+        "@sanity/ui": "^2.1",
+        "react": "^18",
+        "react-dom": "^18",
+        "sanity": "^3.37.0",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/@sanity/document-internationalization/node_modules/@sanity/icons": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
+      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
+      }
+    },
     "node_modules/@sanity/eslint-config-studio": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sanity/eslint-config-studio/-/eslint-config-studio-4.0.0.tgz",
@@ -3264,6 +3302,64 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@sanity/incompatible-plugin": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/incompatible-plugin/-/incompatible-plugin-1.0.4.tgz",
+      "integrity": "sha512-2z39G9PTM8MXOF4fJNx3TG4tH0RrTjtH6dVLW93DSjCPbIS7FgCY5yWjZfQ+HVkwhLsF7ATDAGLA/jp65pFjAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^1.3",
+        "react-copy-to-clipboard": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9 || ^17 || ^18",
+        "react-dom": "^16.9 || ^17 || ^18"
+      }
+    },
+    "node_modules/@sanity/incompatible-plugin/node_modules/@sanity/icons": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.10.tgz",
+      "integrity": "sha512-5wVG/vIiGuGrSmq+Bl3PY7XDgQrGv0fyHdJI64FSulnr2wH3NMqZ6C59UFxnrZ93sr7kOt0zQFoNv2lkPBi0Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.9 || ^17 || ^18"
+      }
+    },
+    "node_modules/@sanity/language-filter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/language-filter/-/language-filter-4.0.2.tgz",
+      "integrity": "sha512-guL7vZv/QwDdbzVbCA8YqY8G0tH6KW2obyp5UCbFvFy9NqlmfuaHtle/VIO+UwqbCXck2Xpz0WihFeQHHjhCcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^2.11.7",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^2.1.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@sanity/ui": "^2.1.0",
+        "@sanity/util": "^3.36.4",
+        "react": "^18",
+        "react-dom": "^18",
+        "sanity": "^3.36.4",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/@sanity/language-filter/node_modules/@sanity/icons": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
+      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
       }
     },
     "node_modules/@sanity/logos": {
@@ -10699,6 +10795,78 @@
       },
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/sanity-plugin-internationalized-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-internationalized-array/-/sanity-plugin-internationalized-array-2.0.0.tgz",
+      "integrity": "sha512-NRxAziPAy++veE1nR3JxzrfRXPfhoBK40A3ggSAS0ZMUFJ9aFZajVgmkhkR3kZtff0oFbX0zcHigrhRj0X3TyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^2.11.7",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/language-filter": "^4.0.2",
+        "@sanity/ui": "^2.1.0",
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21",
+        "suspend-react": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@sanity/ui": "^2.1.0",
+        "react": "^18",
+        "react-dom": "^18",
+        "sanity": "^3.36.4",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/sanity-plugin-internationalized-array/node_modules/@sanity/icons": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
+      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
+      }
+    },
+    "node_modules/sanity-plugin-utils": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-utils/-/sanity-plugin-utils-1.6.5.tgz",
+      "integrity": "sha512-QJOBaNSIR7nG8xaSRD/CsqPMz8ZMZIkJ2pCIzB14uD9J4iiCaRh6V4R6We6L4gNJ/Pr57AuzQS/SGqlyTue5Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^2.11.8",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "styled-components": "^6.1.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/ui": "^1.0 || ^2.0",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-fast-compare": "^3.2.2",
+        "rxjs": "^7.8.1",
+        "sanity": "^3.43.0",
+        "styled-components": "^6.1.11"
+      }
+    },
+    "node_modules/sanity-plugin-utils/node_modules/@sanity/icons": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
+      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
       }
     },
     "node_modules/sanity/node_modules/ansi-styles": {

--- a/cms/package.json
+++ b/cms/package.json
@@ -15,6 +15,7 @@
     "sanity"
   ],
   "dependencies": {
+    "@sanity/document-internationalization": "^3.0.0",
     "@sanity/vision": "^3.45.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
         {id: 'nb', title: '🇳🇴 Norwegian (Bokmål)'},
         {id: 'en', title: '🇬🇧 English'},
       ],
-      schemaTypes: ['article', 'event'],
+      schemaTypes: ['article', 'event', 'frontpage', 'role'],
       metadataFields: [
         defineField({
           name: 'slug',

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -1,9 +1,10 @@
-import {defineConfig} from 'sanity'
+import {defineConfig, defineField} from 'sanity'
 import {StructureBuilder, StructureResolverContext, structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
 import {HomeIcon, DocumentTextIcon, CalendarIcon, UserIcon} from '@sanity/icons'
 import {documentInternationalization} from '@sanity/document-internationalization'
+import {isUniqueOtherThanLanguage} from './helperFunctions'
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
 const singletonActions = new Set(['publish', 'discardChanges', 'restore'])
@@ -37,6 +38,15 @@ export default defineConfig({
         {id: 'en', title: '🇬🇧 English'},
       ],
       schemaTypes: ['article'],
+      metadataFields: [
+        defineField({
+          name: 'slug',
+          type: 'slug',
+          options: {
+            isUnique: isUniqueOtherThanLanguage,
+          },
+        }),
+      ],
     }),
     structureTool({structure: deskStructure}),
     visionTool(),

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
         {id: 'nb', title: '🇳🇴 Norwegian (Bokmål)'},
         {id: 'en', title: '🇬🇧 English'},
       ],
-      schemaTypes: ['article'],
+      schemaTypes: ['article', 'event'],
       metadataFields: [
         defineField({
           name: 'slug',

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -3,7 +3,10 @@ import {StructureBuilder, StructureResolverContext, structureTool} from 'sanity/
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
 import {HomeIcon, DocumentTextIcon, CalendarIcon, UserIcon} from '@sanity/icons'
-import {documentInternationalization} from '@sanity/document-internationalization'
+import {
+  documentInternationalization,
+  DeleteTranslationAction,
+} from '@sanity/document-internationalization'
 import {isUniqueOtherThanLanguage} from './helperFunctions'
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
@@ -57,10 +60,14 @@ export default defineConfig({
     templates: (templates) => templates.filter(({schemaType}) => !singletonTypes.has(schemaType)),
   },
   document: {
-    // filter out actions that should not be available for singleton pages
-    actions: (input, context) =>
-      singletonTypes.has(context.schemaType)
+    actions: (input, context) => {
+      // add the delete translation action to all documents
+      input.push(DeleteTranslationAction)
+
+      // filter out actions that should not be available for singleton pages
+      return singletonTypes.has(context.schemaType)
         ? input.filter(({action}) => action && singletonActions.has(action))
-        : input,
+        : input
+    },
   },
 })

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -13,15 +13,40 @@ import {isUniqueOtherThanLanguage} from './helperFunctions'
 const singletonActions = new Set(['publish', 'discardChanges', 'restore'])
 const singletonTypes = new Set(['frontpage'])
 
+const SINGLETONS = [{id: 'frontpage', title: 'Forside', _type: 'frontpage'}]
+
+const LANGUAGES = [
+  {id: `nb`, title: `🇳🇴 Norwegian (Bokmål)`},
+  {id: `en`, title: `🇬🇧 English`},
+]
+
 const deskStructure = (S: StructureBuilder) =>
   S.list()
     .title('Innhold')
     .items([
-      S.listItem()
-        .title('Forside')
-        .id('frontpage')
-        .child(S.document().schemaType('frontpage').documentId('frontpage'))
-        .icon(HomeIcon),
+      ...SINGLETONS.map((singleton) =>
+        S.listItem()
+          .title(singleton.title)
+          .id(singleton.id)
+          .icon(HomeIcon)
+          .child(
+            S.list()
+              .title(singleton.title)
+              .id(singleton.id)
+
+              .items(
+                LANGUAGES.map((language) =>
+                  S.documentListItem()
+                    .schemaType(`frontpage`)
+                    .id(`${singleton.id}-${language.id}`)
+                    .title(`${singleton.title} (${language.id.toLocaleUpperCase()})`),
+                ),
+              )
+              .canHandleIntent(
+                (intentName, params) => intentName === 'edit' && params.id.startsWith(singleton.id),
+              ),
+          ),
+      ),
       S.documentTypeListItem('article').title('Artikler').icon(DocumentTextIcon),
       S.documentTypeListItem('event').title('Forestillinger').icon(CalendarIcon),
       S.documentTypeListItem('role').title('Roller').icon(UserIcon),

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -3,6 +3,7 @@ import {StructureBuilder, StructureResolverContext, structureTool} from 'sanity/
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
 import {HomeIcon, DocumentTextIcon, CalendarIcon, UserIcon} from '@sanity/icons'
+import {documentInternationalization} from '@sanity/document-internationalization'
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
 const singletonActions = new Set(['publish', 'discardChanges', 'restore'])
@@ -29,7 +30,17 @@ export default defineConfig({
   projectId: process.env.SANITY_STUDIO_PROJECT_ID ?? '0chpibsu',
   dataset: process.env.SANITY_STUDIO_DATASET ?? 'production',
 
-  plugins: [structureTool({structure: deskStructure}), visionTool()],
+  plugins: [
+    documentInternationalization({
+      supportedLanguages: [
+        {id: 'nb', title: '🇳🇴 Norwegian (Bokmål)'},
+        {id: 'en', title: '🇬🇧 English'},
+      ],
+      schemaTypes: ['article'],
+    }),
+    structureTool({structure: deskStructure}),
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -57,7 +57,11 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
-    templates: (templates) => templates.filter(({schemaType}) => !singletonTypes.has(schemaType)),
+    templates: (templates) => {
+      return templates
+        .filter(({schemaType}) => !singletonTypes.has(schemaType))
+        .filter((template) => !['article', 'event'].includes(template.id))
+    },
   },
   document: {
     actions: (input, context) => {

--- a/cms/schemaTypes/articleType.ts
+++ b/cms/schemaTypes/articleType.ts
@@ -19,6 +19,12 @@ export const articleType = defineType({
           ),
     }),
     defineField({
+      name: 'language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',

--- a/cms/schemaTypes/articleType.ts
+++ b/cms/schemaTypes/articleType.ts
@@ -1,4 +1,5 @@
 import {defineField, defineType} from 'sanity'
+import {isUniqueOtherThanLanguage} from '../helperFunctions'
 
 export const articleType = defineType({
   name: 'article',
@@ -28,7 +29,7 @@ export const articleType = defineType({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
-      options: {source: 'Tittel'},
+      options: {source: 'Tittel', isUnique: isUniqueOtherThanLanguage},
       hidden: ({document}) => !document?.title,
       description: 'Url: fjaereheia.no/xxx',
     }),

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -1,4 +1,5 @@
 import {defineField, defineType} from 'sanity'
+import {isUniqueOtherThanLanguage} from '../helperFunctions'
 
 export const eventType = defineType({
   name: 'event',
@@ -18,10 +19,16 @@ export const eventType = defineType({
       ],
     }),
     defineField({
+      name: 'language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
       name: 'slug',
       title: 'slug',
       type: 'slug',
-      options: {source: 'tittel'},
+      options: {source: 'tittel', isUnique: isUniqueOtherThanLanguage},
       hidden: ({document}) => !document?.tittel,
       description: 'Url: fjaereheia.no/xxx',
     }),

--- a/cms/schemaTypes/frontpage.ts
+++ b/cms/schemaTypes/frontpage.ts
@@ -15,6 +15,12 @@ export const frontpage = defineType({
       ],
     }),
     defineField({
+      name: 'language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
       name: 'preamble',
       title: 'Ingress',
       type: 'string',

--- a/cms/schemaTypes/roleType.ts
+++ b/cms/schemaTypes/roleType.ts
@@ -12,6 +12,12 @@ export const roleType = defineType({
       validation: (rule) => rule.required().min(2).max(50).error(`Må ha navn på minst 2 bokstaver`),
     }),
     defineField({
+      name: 'language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
       name: 'image',
       title: 'Bilde',
       type: 'image',

--- a/frontend/app/queries/frontpage-queries.ts
+++ b/frontend/app/queries/frontpage-queries.ts
@@ -1,3 +1,3 @@
 import groq from "groq";
 
-export const FRONTPAGE_QUERY = groq`*[_type=="frontpage"]{title, preamble, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]`;
+export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]`;


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
[lenke til notion](https://www.notion.so/bekks/Legg-til-mulighet-for-opprette-innhold-p-flere-spr-k-i-Sanity-baf823c4eae5486ea7a249db90847423?pvs=4)

## Beskrivelse.

- Brukere kan nå velge språk i Sanity når de oppretter nye forestillinger eller artikkler. Frontpage har to versjoner, EN og NB (norsk bokmål). 
- Ved oppretting av nye singletons må createSingletons.ts kjøres, er dokumentert hvordan i scriptet.
- Ved opprettelse av et dokument har man valget om å legge til en translation og da lages et metadata dokument som kobler versjonene sammen. 
- Kan hente ulike versjoner med language=="id" i GROQ der id er "en" || "nb". 
- Slugs kan også være det samme for to versjoner av samme dokument, gjøres med isUniqueOtherThanLanguage i helperFunctions.ts

## Skjermbilder.
![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/a72cf3f2-40f0-4df2-ba82-670d69816890)
**Frontpage med to versjoner**

![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/e49280dc-9515-47c9-a87d-7486669c42de)
**Artikkel med side om side engelsk og norsk versjon, samme slug**

![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/8d58a401-ef7e-44cc-9f0c-9b7a4d27af81)
**Detailed view viser hvilket språk dokumentet er**
![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/a8ecdc99-17f3-408a-9437-62d570c242e6)
**GROQ query med language**
