### PR TITLE
Adds date array and duration fields to eventType

### DIFF
--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -28,6 +28,20 @@ export const eventType = defineType({
       type: 'string',
     }),
     defineField({
+      name: 'dates',
+      title: 'Datoer',
+      type: 'array',
+      of: [{type: 'datetime'}],
+      validation: (rule) => [rule.required().min(1).error('Minst en dato er påkrevd.')],
+    }),
+    defineField({
+      name: 'duration',
+      title: 'Varighet',
+      type: 'string',
+      placeholder: 'e.g 1 time og 30 minutter',
+      validation: (rule) => [rule.required().error('Varighet er påkrevd.')],
+    }),
+    defineField({
       name: 'bilde',
       type: 'image',
       validation: (rule) => [rule.required()],


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
[lenke til notion](https://www.notion.so/bekks/Legg-til-varighet-og-dato-p-event-56fe3655ddfa4f48809fbd55952f17c3?pvs=4)

## Beskrivelse.
Lagt til felter for datoer og varighet i eventType

## Skjermbilder.
![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/66a1f148-b369-4eac-b1ee-13d358aba304)
