### PR TITLE
added roletype to sanity

### DIFF
--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -2,7 +2,7 @@ import {defineConfig} from 'sanity'
 import {StructureBuilder, StructureResolverContext, structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
-import {HomeIcon, DocumentTextIcon, CalendarIcon} from '@sanity/icons'
+import {HomeIcon, DocumentTextIcon, CalendarIcon, UserIcon} from '@sanity/icons'
 
 //singleton pages. Before you add the type to singletontypes, the page should be created, since create is not a valid action for singleton types
 const singletonActions = new Set(['publish', 'discardChanges', 'restore'])
@@ -19,6 +19,7 @@ const deskStructure = (S: StructureBuilder) =>
         .icon(HomeIcon),
       S.documentTypeListItem('article').title('Artikler').icon(DocumentTextIcon),
       S.documentTypeListItem('event').title('Forestillinger').icon(CalendarIcon),
+      S.documentTypeListItem('role').title('Roller').icon(UserIcon),
     ])
 
 export default defineConfig({

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -1,5 +1,6 @@
 import {frontpage} from './frontpage'
 import {articleType} from './articleType'
 import {eventType} from './eventType'
+import {roleType} from './roleType'
 
-export const schemaTypes = [articleType, eventType, frontpage]
+export const schemaTypes = [articleType, eventType, frontpage, roleType]

--- a/cms/schemaTypes/roleType.ts
+++ b/cms/schemaTypes/roleType.ts
@@ -1,0 +1,33 @@
+import {defineField, defineType} from 'sanity'
+
+export const roleType = defineType({
+  name: 'role',
+  title: 'Rolle',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Navn',
+      type: 'string',
+      validation: (rule) => rule.required().min(2).max(50).error(`Må ha navn på minst 2 bokstaver`),
+    }),
+    defineField({
+      name: 'image',
+      title: 'Bilde',
+      type: 'image',
+      description: 'Legg til et bilde',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'text',
+      title: 'Biografi',
+      description: 'Hold det kort',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+    }),
+  ],
+})


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.


## Linke til oppgave (Notion).
https://www.notion.so/bekks/Opprett-rolletype-6f7d91ac071246e389810745f2398048?pvs=4
## Beskrivelse.
Lagt til roleType i sanity. Har ikke laget en kobling til eventType da det blir mer naturlig at man kan velge roller fra event, ettersom roller ikke skal ha en egen side. La til tekst boks (ikke required) hvis man skal ha hovedrolle med mer informasjon
## Skjermbilder.
![Screenshot 2024-06-27 at 10 47 09](https://github.com/Fjaereheia/fjaereheia/assets/102430264/3b1b574c-3783-4f35-82ba-3936c1240955)
