### PR TITLE
Alt text portabletext

### DIFF
--- a/cms/schemaTypes/articleType.ts
+++ b/cms/schemaTypes/articleType.ts
@@ -36,14 +36,14 @@ export const articleType = defineType({
           type: 'block',
         },
         {
-          type: 'image',
+          type: 'customImage',
         },
       ],
     }),
     defineField({
       name: 'image',
       title: 'Bilde',
-      type: 'image',
+      type: 'customImage',
       description: 'Legg til et bilde',
     }),
     defineField({

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -47,16 +47,7 @@ export const eventType = defineType({
     defineField({
       name: 'image',
       title: 'Bilde',
-      type: 'image',
-      validation: (rule) => [rule.required()],
-      fields: [
-        {
-          name: 'caption',
-          type: 'string',
-          title: 'Bildetekst',
-          validation: (rule) => [rule.required().min(1).error('Bildetekst er påkrevd')],
-        },
-      ],
+      type: 'customImage',
     }),
     defineField({
       name: 'text',
@@ -67,7 +58,7 @@ export const eventType = defineType({
           type: 'block',
         },
         {
-          type: 'image',
+          type: 'customImage',
         },
       ],
     }),

--- a/cms/schemaTypes/frontpage.ts
+++ b/cms/schemaTypes/frontpage.ts
@@ -22,16 +22,8 @@ export const frontpage = defineType({
     defineField({
       name: 'image',
       title: 'Bilde',
-      type: 'image',
+      type: 'customImage',
       validation: (rule) => [rule.required()],
-      fields: [
-        {
-          name: 'caption',
-          type: 'string',
-          title: 'Bildetekst',
-          validation: (rule) => [rule.required().min(1).error('Bildetekst er påkrevd')],
-        },
-      ],
     }),
     defineField({
       name: 'event',

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -2,5 +2,6 @@ import {frontpage} from './frontpage'
 import {articleType} from './articleType'
 import {eventType} from './eventType'
 import {roleType} from './roleType'
+import customImage from './objects/customImage'
 
-export const schemaTypes = [articleType, eventType, frontpage, roleType]
+export const schemaTypes = [articleType, eventType, frontpage, roleType, customImage]

--- a/cms/schemaTypes/objects/customImage.ts
+++ b/cms/schemaTypes/objects/customImage.ts
@@ -1,0 +1,18 @@
+import {defineField} from 'sanity'
+
+export default {
+  name: 'customImage',
+  title: 'Bilde',
+  type: 'image',
+  options: {
+    hotspot: true,
+  },
+  fields: [
+    defineField({
+      title: 'Alternativ Tekst',
+      name: 'alt',
+      type: 'string',
+      validation: (rule) => [rule.required().min(1).error('Bildetekst er påkrevd')],
+    }),
+  ],
+}

--- a/cms/schemaTypes/roleType.ts
+++ b/cms/schemaTypes/roleType.ts
@@ -14,7 +14,7 @@ export const roleType = defineType({
     defineField({
       name: 'image',
       title: 'Bilde',
-      type: 'image',
+      type: 'customImage',
       description: 'Legg til et bilde',
       validation: (rule) => rule.required(),
     }),


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Legge-til-alt-tekst-i-bilder-i-PortableText-b75b02aef7f64e3d931e71a9c6c151cf?pvs=4)

## Beskrivelse.
Alle bilde referanser er oppdatert til å bruke customImage som krever bilde tekst for alle bilder. Dette var ment for å håndtere bilder i RichText men kunne da påføres alle bilderefs så det er likt alle steder

## Skjermbilder.
![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/086c26e7-5007-457f-b678-7ad65c9a4a5f)
I vanlig forestilling

![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/c1249fdb-6f9a-4541-ab34-244813869dbb)
Inne i en RichTextEditor
