### PR TITLE
Updated ref for icon becmoing invalid on build for frontend

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -12,7 +12,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/public/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Feilmelding-ved-henting-av-favicon-dukker-opp-i-loggene-p-vercel-2ed50a5183f54757822cc49402edb467?pvs=4)

## Beskrivelse.
Var en feil i href for icon som gjorde den ikke ble funnet på build. Oppdaterte href så den nå finner riktig fil i prod

## Skjermbilder.
