### PR TITLE
Portable text alt

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -1483,6 +1483,14 @@
         },
         "optional": true
       },
+      "text": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "content"
+        },
+        "optional": true
+      },
       "event": {
         "type": "objectAttribute",
         "value": {

--- a/cms/schemaTypes/frontpage.ts
+++ b/cms/schemaTypes/frontpage.ts
@@ -1,14 +1,19 @@
-import {defineType, defineField} from 'sanity'
+import {defineType, defineField, Rule} from 'sanity'
 
 export const frontpage = defineType({
   name: 'frontpage',
   title: 'Forside',
   type: 'document',
+  groups: [
+    {title: 'Innhold', name: 'content'},
+    {title: 'Standard visning', name: 'default'},
+  ],
   fields: [
     defineField({
       name: 'title',
       title: 'Tittel',
       type: 'string',
+      group: 'content',
       validation: (rule) => [
         rule.max(100).warning('Anbefaler kortere tittel.'),
         rule.required().min(1).error('Tittel er påkrevd'),
@@ -24,12 +29,28 @@ export const frontpage = defineType({
       name: 'preamble',
       title: 'Ingress',
       type: 'string',
+      group: 'content',
     }),
     defineField({
       name: 'image',
       title: 'Bilde',
       type: 'customImage',
+      group: 'content',
       validation: (rule) => [rule.required()],
+    }),
+    defineField({
+      name: 'text',
+      title: 'Tekst',
+      type: 'content',
+      group: 'default',
+      validation: (rule: Rule) =>
+        rule.custom((text, context) => {
+          const event = context.document?.event
+          if (!event && !text) {
+            return 'Tekst er påkrevd når Forestilling ikke er valgt'
+          }
+          return true
+        }),
     }),
     defineField({
       name: 'event',

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -8,7 +8,7 @@ interface PortabelTextProps {
 export default function PortableTextComponent({ textData }: PortabelTextProps) {
   const customComponents = {
     types: {
-      image: ({
+      customImage: ({
         value,
       }: PortableTextComponentProps<{
         asset: { url: string };

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -2,11 +2,11 @@ import { PortableText, PortableTextComponentProps } from "@portabletext/react";
 import { Content } from "sanity/types";
 import urlFor from "~/functions/imageUrlBuilder";
 
-interface PortabelTextProps {
+interface PortableTextProps {
   textData: Content;
 }
 
-export default function PortableTextComponent({ textData }: PortabelTextProps) {
+export default function PortableTextComponent({ textData }: PortableTextProps) {
   const customComponents = {
     types: {
       customImage: ({

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -1,5 +1,6 @@
 import { PortableText, PortableTextComponentProps } from "@portabletext/react";
 import { Content } from "sanity/types";
+import urlFor from "~/functions/imageUrlBuilder";
 
 interface PortabelTextProps {
   textData: Content;
@@ -11,12 +12,12 @@ export default function PortableTextComponent({ textData }: PortabelTextProps) {
       customImage: ({
         value,
       }: PortableTextComponentProps<{
-        asset: { url: string };
+        asset: { _ref: string; _type: "reference" };
         alt: string;
       }>) => {
         return (
           <img
-            src={value.asset.url}
+            src={urlFor(value.asset?._ref)}
             alt={value.alt}
             style={{ maxWidth: "100%" }}
           />

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -1,0 +1,35 @@
+import { PortableText, PortableTextComponentProps } from "@portabletext/react";
+import { Content } from "sanity/types";
+
+interface PortabelTextProps {
+  textData: Content;
+}
+
+export default function PortableTextComponent({ textData }: PortabelTextProps) {
+  const customComponents = {
+    types: {
+      image: ({
+        value,
+      }: PortableTextComponentProps<{
+        asset: { url: string };
+        alt: string;
+      }>) => {
+        return (
+          <img
+            src={value.asset.url}
+            alt={value.alt}
+            style={{ maxWidth: "100%" }}
+          />
+        );
+      },
+    },
+  };
+
+  return (
+    <div>
+      {textData && (
+        <PortableText value={textData} components={customComponents} />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/functions/imageUrlBuilder.tsx
+++ b/frontend/app/functions/imageUrlBuilder.tsx
@@ -3,6 +3,7 @@ import imageUrlBuilder from "@sanity/image-url";
 
 const builder = imageUrlBuilder(client);
 
-export default function urlFor(source: string) {
+export default function urlFor(source: string | undefined) {
+  if (!source) return "";
   return builder.image(source).url();
 }

--- a/frontend/app/queries/frontpage-queries.ts
+++ b/frontend/app/queries/frontpage-queries.ts
@@ -1,3 +1,3 @@
 import groq from "groq";
 
-export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]`;
+export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble, text, image}}[0]`;

--- a/frontend/app/queries/frontpage-queries.ts
+++ b/frontend/app/queries/frontpage-queries.ts
@@ -1,3 +1,3 @@
 import groq from "groq";
 
-export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]`;
+export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]`;

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { json, type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { client } from "sanity/clientConfig";
 import { FRONTPAGE_QUERYResult } from "sanity/types";
+import PortableTextComponent from "~/components/PortableTextComponent";
 import { FRONTPAGE_QUERY } from "~/queries/frontpage-queries";
 import ButtonLink from "~/components/ButtonLink";
 
@@ -29,6 +30,7 @@ export async function loader() {
 
 export default function Index() {
   const data = useLoaderData<typeof loader>() as FRONTPAGE_QUERYResult;
+
   return (
     <div>
       <h1>{data?.title}</h1>
@@ -43,20 +45,14 @@ export default function Index() {
           <h2>Forestilling: {data?.event?.title}</h2>
           <p>Ingress: {data?.event?.preamble}</p>
           <img src={data?.event?.imageUrl || ""} />
-          <div>
-            {data?.event?.text?.map((item, index) => (
-              <div key={index}>
-                {item._type === "block" && item.children ? (
-                  <p>{item.children.map((child) => child.text).join("")}</p>
-                ) : item._type === "customImage" && item.asset?.url ? (
-                  <img src={item.asset.url} alt="Sanity Image" />
-                ) : null}
-              </div>
-            ))}
-          </div>
+          {data?.event?.text ? (
+            <PortableTextComponent textData={data?.event?.text} />
+          ) : null}
         </>
       ) : (
-        <p> no content available</p>
+        <>
+          {data?.text ? <PortableTextComponent textData={data?.text} /> : null}
+        </>
       )}
     </div>
   );

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -3,6 +3,7 @@ import { Link, useLoaderData } from "@remix-run/react";
 import { client } from "sanity/clientConfig";
 import { FRONTPAGE_QUERYResult } from "sanity/types";
 import PortableTextComponent from "~/components/PortableTextComponent";
+import urlFor from "~/functions/imageUrlBuilder";
 import { FRONTPAGE_QUERY } from "~/queries/frontpage-queries";
 import ButtonLink from "~/components/ButtonLink";
 
@@ -35,7 +36,10 @@ export default function Index() {
     <div>
       <h1>{data?.title}</h1>
       <p>{data?.preamble}</p>
-      <img src={data?.imageUrl || ""} />
+      <img
+        src={urlFor(data?.event?.image?.asset?._ref) || ""}
+        alt={data?.event?.image?.alt}
+      />
       <br />
       <ButtonLink url="/artikler" buttonText="Artikler (Info)"></ButtonLink>
       <ButtonLink url="/event" buttonText="Program"></ButtonLink>
@@ -44,7 +48,10 @@ export default function Index() {
         <>
           <h2>Forestilling: {data?.event?.title}</h2>
           <p>Ingress: {data?.event?.preamble}</p>
-          <img src={data?.event?.imageUrl || ""} />
+          <img
+            src={urlFor(data?.event?.image?.asset?._ref) || ""}
+            alt={data?.event?.image?.alt || ""}
+          />
           {data?.event?.text ? (
             <PortableTextComponent textData={data?.event?.text} />
           ) : null}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1965,6 +1965,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-1.0.2.tgz",
       "integrity": "sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "@portabletext/react": "^3.1.0",
         "@remix-run/react": "^2.9.2",
         "@remix-run/serve": "^2.9.2",
         "@sanity/client": "^6.20.1",
@@ -1426,6 +1427,43 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@portabletext/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-ZGHlvS+NvId9RSqnflN8xF2KVZgAgD399dK1GaycurnGNZGZYTd5nZmc8by1yL76Ar8n/dbVtouUDJIkO4Tupw==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.15",
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || >=19.0.0-rc"
+      }
+    },
+    "node_modules/@portabletext/toolkit": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.15.tgz",
+      "integrity": "sha512-KRNEUAd6eOxE9y591qC0sE24ZG2q27OHXe0dsPclj4IoEzf8aEuDcHR64wfFtB0aHq9Wdx3pIinmhZZcl35/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@portabletext/types": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.13.tgz",
+      "integrity": "sha512-5xk5MSyQU9CrDho3Rsguj38jhijhD36Mk8S6mZo3huv6PM+t4M/5kJN2KFIxgvt4ONpvOEs1pVIZAV0cL0Vi+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
       }
     },
     "node_modules/@remix-run/dev": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@portabletext/react": "^3.1.0",
     "@remix-run/react": "^2.9.2",
     "@remix-run/serve": "^2.9.2",
     "@sanity/client": "^6.20.1",

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -509,56 +509,13 @@ export type EVENT_QUERYResult = Array<{
 export type FRONTPAGE_QUERYResult = {
   title: string | null;
   preamble: string | null;
-  text: Content | null;
+  text?: Content;
   event: {
     title: string | null;
     preamble: string | null;
     imageUrl: string | null;
     slug: Slug | null;
-    text: Array<
-      | {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          asset: null;
-        }
-      | {
-          asset: {
-            _id: string;
-            url: string | null;
-          } | null;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          alt?: string;
-          _type: "customImage";
-        }
-      | {
-          children?: Array<{
-            marks?: Array<string>;
-            text?: string;
-            _type: "span";
-            _key: string;
-          }>;
-          style?:
-            | "blockquote"
-            | "h1"
-            | "h2"
-            | "h3"
-            | "h4"
-            | "h5"
-            | "h6"
-            | "normal";
-          listItem?: "bullet" | "number";
-          markDefs?: Array<{
-            href?: string;
-            _type: "link";
-            _key: string;
-          }>;
-          level?: number;
-          _type: "block";
-          asset: null;
-        }
-    > | null;
+    text: Content;
   } | null;
   imageUrl: string | null;
 } | null;

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -68,46 +68,42 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type Content = Array<
-  | {
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: "span";
-        _key: string;
-      }>;
-      style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-      listItem?: "bullet" | "number";
-      markDefs?: Array<{
-        href?: string;
-        _type: "link";
-        _key: string;
-      }>;
-      level?: number;
-      _type: "block";
-      _key: string;
-    }
-  | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      alt?: string;
-      _type: "customImage";
-      _key: string;
-    }
-  | {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: "quote";
-    }
->;
+export type Content = Array<{
+  children?: Array<{
+    marks?: Array<string>;
+    text?: string;
+    _type: "span";
+    _key: string;
+  }>;
+  style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+  listItem?: "bullet" | "number";
+  markDefs?: Array<{
+    href?: string;
+    _type: "link";
+    _key: string;
+  }>;
+  level?: number;
+  _type: "block";
+  _key: string;
+} | {
+  asset?: {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+  };
+  hotspot?: SanityImageHotspot;
+  crop?: SanityImageCrop;
+  alt?: string;
+  _type: "customImage";
+  _key: string;
+} | {
+  _ref: string;
+  _type: "reference";
+  _weak?: boolean;
+  _key: string;
+  [internalGroqTypeReferenceTo]?: "quote";
+}>;
 
 export type Quote = {
   _id: string;
@@ -184,42 +180,36 @@ export type TranslationMetadata = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  translations?: Array<
-    {
-      _key: string;
-    } & InternationalizedArrayReferenceValue
-  >;
+  translations?: Array<{
+    _key: string;
+  } & InternationalizedArrayReferenceValue>;
   schemaTypes?: Array<string>;
   slug?: Slug;
 };
 
 export type InternationalizedArrayReferenceValue = {
   _type: "internationalizedArrayReferenceValue";
-  value?:
-    | {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "article";
-      }
-    | {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "event";
-      }
-    | {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "frontpage";
-      }
-    | {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "role";
-      };
+  value?: {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "article";
+  } | {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "event";
+  } | {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "frontpage";
+  } | {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "role";
+  };
 };
 
 export type Role = {
@@ -352,34 +342,11 @@ export type Slug = {
   source?: string;
 };
 
-export type InternationalizedArrayReference = Array<
-  {
-    _key: string;
-  } & InternationalizedArrayReferenceValue
->;
+export type InternationalizedArrayReference = Array<{
+  _key: string;
+} & InternationalizedArrayReferenceValue>;
 
-export type AllSanitySchemaTypes =
-  | SanityImagePaletteSwatch
-  | SanityImagePalette
-  | SanityImageDimensions
-  | SanityFileAsset
-  | Geopoint
-  | Content
-  | Quote
-  | SanityImageCrop
-  | SanityImageHotspot
-  | SanityImageAsset
-  | SanityAssetSourceData
-  | SanityImageMetadata
-  | TranslationMetadata
-  | InternationalizedArrayReferenceValue
-  | Role
-  | Frontpage
-  | Article
-  | Event
-  | CustomImage
-  | Slug
-  | InternationalizedArrayReference;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | TranslationMetadata | InternationalizedArrayReferenceValue | Role | Frontpage | Article | Event | CustomImage | Slug | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../frontend/app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -505,17 +472,26 @@ export type EVENT_QUERYResult = Array<{
 }>;
 // Source: ../frontend/app/queries/frontpage-queries.ts
 // Variable: FRONTPAGE_QUERY
-// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]
+// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble, text, image}}[0]
 export type FRONTPAGE_QUERYResult = {
   title: string | null;
   preamble: string | null;
-  text?: Content;
+  text: Content | null;
   event: {
     title: string | null;
     preamble: string | null;
-    imageUrl: string | null;
-    slug: Slug | null;
-    text: Content;
+    text: Content | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+    } | null;
   } | null;
-  imageUrl: string | null;
 } | null;

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -68,42 +68,46 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type Content = Array<{
-  children?: Array<{
-    marks?: Array<string>;
-    text?: string;
-    _type: "span";
-    _key: string;
-  }>;
-  style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-  listItem?: "bullet" | "number";
-  markDefs?: Array<{
-    href?: string;
-    _type: "link";
-    _key: string;
-  }>;
-  level?: number;
-  _type: "block";
-  _key: string;
-} | {
-  asset?: {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-  };
-  hotspot?: SanityImageHotspot;
-  crop?: SanityImageCrop;
-  alt?: string;
-  _type: "customImage";
-  _key: string;
-} | {
-  _ref: string;
-  _type: "reference";
-  _weak?: boolean;
-  _key: string;
-  [internalGroqTypeReferenceTo]?: "quote";
-}>;
+export type Content = Array<
+  | {
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    }
+  | {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+      _key: string;
+    }
+  | {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      _key: string;
+      [internalGroqTypeReferenceTo]?: "quote";
+    }
+>;
 
 export type Quote = {
   _id: string;
@@ -180,36 +184,42 @@ export type TranslationMetadata = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
-  translations?: Array<{
-    _key: string;
-  } & InternationalizedArrayReferenceValue>;
+  translations?: Array<
+    {
+      _key: string;
+    } & InternationalizedArrayReferenceValue
+  >;
   schemaTypes?: Array<string>;
   slug?: Slug;
 };
 
 export type InternationalizedArrayReferenceValue = {
   _type: "internationalizedArrayReferenceValue";
-  value?: {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "article";
-  } | {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "event";
-  } | {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "frontpage";
-  } | {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "role";
-  };
+  value?:
+    | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "article";
+      }
+    | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "event";
+      }
+    | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "frontpage";
+      }
+    | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "role";
+      };
 };
 
 export type Role = {
@@ -256,6 +266,7 @@ export type Frontpage = {
     alt?: string;
     _type: "customImage";
   };
+  text?: Content;
   event?: {
     _ref: string;
     _type: "reference";
@@ -341,9 +352,34 @@ export type Slug = {
   source?: string;
 };
 
-export type InternationalizedArrayReference = Array<{
-  _key: string;
-} & InternationalizedArrayReferenceValue>;
+export type InternationalizedArrayReference = Array<
+  {
+    _key: string;
+  } & InternationalizedArrayReferenceValue
+>;
+
+export type AllSanitySchemaTypes =
+  | SanityImagePaletteSwatch
+  | SanityImagePalette
+  | SanityImageDimensions
+  | SanityFileAsset
+  | Geopoint
+  | Content
+  | Quote
+  | SanityImageCrop
+  | SanityImageHotspot
+  | SanityImageAsset
+  | SanityAssetSourceData
+  | SanityImageMetadata
+  | TranslationMetadata
+  | InternationalizedArrayReferenceValue
+  | Role
+  | Frontpage
+  | Article
+  | Event
+  | CustomImage
+  | Slug
+  | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../frontend/app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -469,47 +505,60 @@ export type EVENT_QUERYResult = Array<{
 }>;
 // Source: ../frontend/app/queries/frontpage-queries.ts
 // Variable: FRONTPAGE_QUERY
-// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]
+// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble ,"imageUrl": image.asset->url, slug , text [] {..., asset-> { _id, url}}} , "imageUrl": image.asset->url}[0]
 export type FRONTPAGE_QUERYResult = {
   title: string | null;
   preamble: string | null;
+  text: Content | null;
   event: {
     title: string | null;
     preamble: string | null;
     imageUrl: string | null;
     slug: Slug | null;
-    text: Array<{
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      asset: null;
-    } | {
-      asset: {
-        _id: string;
-        url: string | null;
-      } | null;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      alt?: string;
-      _type: "customImage";
-    } | {
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: "span";
-        _key: string;
-      }>;
-      style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-      listItem?: "bullet" | "number";
-      markDefs?: Array<{
-        href?: string;
-        _type: "link";
-        _key: string;
-      }>;
-      level?: number;
-      _type: "block";
-      asset: null;
-    }> | null;
+    text: Array<
+      | {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          asset: null;
+        }
+      | {
+          asset: {
+            _id: string;
+            url: string | null;
+          } | null;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          alt?: string;
+          _type: "customImage";
+        }
+      | {
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?:
+            | "blockquote"
+            | "h1"
+            | "h2"
+            | "h3"
+            | "h4"
+            | "h5"
+            | "h6"
+            | "normal";
+          listItem?: "bullet" | "number";
+          markDefs?: Array<{
+            href?: string;
+            _type: "link";
+            _key: string;
+          }>;
+          level?: number;
+          _type: "block";
+          asset: null;
+        }
+    > | null;
   } | null;
   imageUrl: string | null;
 } | null;


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.
- Refaktorering.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Lage-en-default-forside-d9d016d86b2248d2859caf35c07d7c7b?pvs=4)
[Lenke til Notion](https://www.notion.so/bekks/Vis-portable-text-i-remix-0b228f91b8d24ebb95cb9624c001d7e6?pvs=4)

## Beskrivelse.
Legger til funksjonalitet for å hente bilder i portableText og en default side i frontpage med en RichTextEditor. Default vises bare hvis event er null. Defaulten er avhengig av PortableTextComponent da RichTextEditor ikke kunne håndtere bilder i frontend uten den. 

## Skjermbilder.
