### PR TITLE
Fixed image not displaying correctly on frontpage

### DIFF
--- a/frontend/app/queries/frontpage-queries.ts
+++ b/frontend/app/queries/frontpage-queries.ts
@@ -1,3 +1,3 @@
 import groq from "groq";
 
-export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble, text, image}}[0]`;
+export const FRONTPAGE_QUERY = groq`*[_type=="frontpage" && language=="nb"]{title, preamble, image, text, event->{title,preamble, text, image}}[0]`;

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -37,8 +37,8 @@ export default function Index() {
       <h1>{data?.title}</h1>
       <p>{data?.preamble}</p>
       <img
-        src={urlFor(data?.event?.image?.asset?._ref) || ""}
-        alt={data?.event?.image?.alt}
+        src={urlFor(data?.image?.asset?._ref) || ""}
+        alt={data?.image?.alt}
       />
       <br />
       <ButtonLink url="/artikler" buttonText="Artikler (Info)"></ButtonLink>

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -472,10 +472,22 @@ export type EVENT_QUERYResult = Array<{
 }>;
 // Source: ../frontend/app/queries/frontpage-queries.ts
 // Variable: FRONTPAGE_QUERY
-// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, text, event->{title,preamble, text, image}}[0]
+// Query: *[_type=="frontpage" && language=="nb"]{title, preamble, image, text, event->{title,preamble, text, image}}[0]
 export type FRONTPAGE_QUERYResult = {
   title: string | null;
   preamble: string | null;
+  image: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "customImage";
+  } | null;
   text: Content | null;
   event: {
     title: string | null;


### PR DESCRIPTION
## Endringstype.
- Bugfix.
- 
## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Fikse-bildebug-p-forsiden-5538422269bd4e6faa7f616559bb1956?pvs=4)

## Beskrivelse.
Fikset en bug der data.event.image ble brukt istedet for data.image i _index.tsx

## Skjermbilder.
