### PR TITLE
Article to info

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -326,7 +326,6 @@
     }
   },
   {
-
     "name": "metaDescription",
     "type": "type",
     "value": {
@@ -341,7 +340,6 @@
     }
   },
   {
-
     "name": "video",
     "type": "document",
     "attributes": {
@@ -1934,6 +1932,13 @@
         }
       },
       "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "language": {
         "type": "objectAttribute",
         "value": {
           "type": "string"

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -3,7 +3,7 @@ import {articleType} from './articleType'
 import {eventType} from './eventType'
 import {roleType} from './roleType'
 import customImage from './objects/customImage'
-import {infopageType} from './infopageType'
+import {infopage} from './infopage'
 import {quoteType} from './objects/quoteType'
 import RichTextEditor from './objects/RichTextEditor'
 import {muxVideo} from './objects/muxVideo'
@@ -16,7 +16,7 @@ export const schemaTypes = [
   frontpage,
   roleType,
   customImage,
-  infopageType,
+  infopage,
   quoteType,
   RichTextEditor,
   muxVideo,

--- a/cms/schemaTypes/infopage.ts
+++ b/cms/schemaTypes/infopage.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField} from 'sanity'
 
-export const infopageType = defineType({
+export const infopage = defineType({
   name: 'infopage',
   title: 'Informasjonsside',
   type: 'document',
@@ -13,6 +13,12 @@ export const infopageType = defineType({
         rule.max(100).warning('Anbefaler kortere tittel.'),
         rule.required().min(1).error('Tittel er påkrevd'),
       ],
+    }),
+    defineField({
+      name: 'language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
     }),
     defineField({
       name: 'text',

--- a/cms/structure/index.ts
+++ b/cms/structure/index.ts
@@ -1,7 +1,16 @@
 import {StructureBuilder} from 'sanity/structure'
 import {CalendarIcon, DocumentTextIcon, HomeIcon, UserIcon, InfoOutlineIcon} from '@sanity/icons'
 
-const SINGLETONS = [{id: 'frontpage', title: 'Forside', _type: 'frontpage'}]
+const SINGLETONS = [
+  {id: 'frontpage', title: 'Forside', _type: 'frontpage', icon: HomeIcon, schemaType: 'frontpage'},
+  {
+    id: 'infopage',
+    title: 'Informasjonsside',
+    _type: 'document',
+    icon: InfoOutlineIcon,
+    schemaType: 'infopage',
+  },
+]
 
 const LANGUAGES = [
   {id: `nb`, title: `🇳🇴 Norwegian (Bokmål)`},
@@ -16,7 +25,7 @@ export const deskStructure = (S: StructureBuilder) =>
         S.listItem()
           .title(singleton.title)
           .id(singleton.id)
-          .icon(HomeIcon)
+          .icon(singleton.icon)
           .child(
             S.list()
               .title(singleton.title)
@@ -25,7 +34,7 @@ export const deskStructure = (S: StructureBuilder) =>
               .items(
                 LANGUAGES.map((language) =>
                   S.documentListItem()
-                    .schemaType(`frontpage`)
+                    .schemaType(singleton.schemaType)
                     .id(`${singleton.id}-${language.id}`)
                     .title(`${singleton.title} (${language.id.toLocaleUpperCase()})`),
                 ),
@@ -38,5 +47,4 @@ export const deskStructure = (S: StructureBuilder) =>
       S.documentTypeListItem('article').title('Artikler').icon(DocumentTextIcon),
       S.documentTypeListItem('event').title('Forestillinger').icon(CalendarIcon),
       S.documentTypeListItem('role').title('Roller').icon(UserIcon),
-      S.documentTypeListItem('infopage').title('Informasjonssider').icon(InfoOutlineIcon),
     ])

--- a/frontend/app/queries/info-queries.ts
+++ b/frontend/app/queries/info-queries.ts
@@ -1,0 +1,8 @@
+import groq from "groq";
+import { client } from "sanity/clientConfig";
+
+export async function getInfoPage(params: { lang: string }) {
+  const INFOPAGE_QUERY = groq`*[_type=="infopage" && language==$lang]{title, text, links[]->{..., slug}}[0]`;
+  const infopage = await client.fetch(INFOPAGE_QUERY, params);
+  return infopage;
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
   return (
     <>
       <Outlet />
-      <StickyFooter infoUrl="/artikler" programUrl="/event" />
+      <StickyFooter infoUrl="/info" programUrl="/event" />
     </>
   );
 }

--- a/frontend/app/routes/($lang)._index.tsx
+++ b/frontend/app/routes/($lang)._index.tsx
@@ -48,7 +48,7 @@ export default function Index() {
         alt={data?.image?.alt}
       />
       <br />
-      <ButtonLink url="/artikler" buttonText="Artikler (Info)"></ButtonLink>
+      <ButtonLink url="/info" buttonText="Info"></ButtonLink>
       <ButtonLink url="/event" buttonText="Program"></ButtonLink>
 
       {data?.event?.title ? (

--- a/frontend/app/routes/info._index.tsx
+++ b/frontend/app/routes/info._index.tsx
@@ -1,0 +1,31 @@
+import { LoaderFunctionArgs, json } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import { INFOPAGE_QUERYResult } from "sanity/types";
+import { getInfoPage } from "~/queries/info-queries";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  if (!params.lang) {
+    params = { lang: "nb" };
+  }
+  const informationPage = await getInfoPage(params as { lang: string });
+
+  if (!informationPage) {
+    return json("Kunne ikke hente infoside", { status: 404 });
+  }
+
+  return json(informationPage);
+}
+
+export default function Info() {
+  const data = useLoaderData<typeof loader>() as INFOPAGE_QUERYResult;
+  return (
+    <div className="flex flex-col items-center mx-6 mt-">
+      <h1 className="text-4xl">{data?.title}</h1>
+      <div className="flex flex-col items-center mx-6 mt-">
+        {data?.links?.map((link) => (
+          <Link to={`/${link.slug?.current}`}>{link.title || ""}</Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -136,52 +136,6 @@ export type Quote = {
   date?: string;
 };
 
-export type Footer = {
-  _id: string;
-  _type: "footer";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  text?: Array<{
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  }>;
-  links?: Array<{
-    href?: string;
-    blank?: boolean;
-    icon?: {
-      name?: "fa-facebook" | "fa-twitter" | "fa-instagram";
-    };
-    _type: "link";
-    _key: string;
-  }>;
-};
-
 export type SanityImageCrop = {
   _type: "sanity.imageCrop";
   top?: number;
@@ -381,6 +335,7 @@ export type Infopage = {
   _updatedAt: string;
   _rev: string;
   title?: string;
+  language?: string;
   text?: Array<{
     children?: Array<{
       marks?: Array<string>;
@@ -551,7 +506,7 @@ export type InternationalizedArrayReference = Array<{
   _key: string;
 } & InternationalizedArrayReferenceValue>;
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | MetaDescription | MetaTitle | Video | Content | Quote | Footer | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Role | Infopage | Frontpage | Article | Event | MuxVideo | CustomImage | Slug | InternationalizedArrayReference;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | MetaDescription | MetaTitle | Video | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Role | Infopage | Frontpage | Article | Event | MuxVideo | CustomImage | Slug | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../frontend/app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -745,4 +700,122 @@ export type FRONTPAGE_QUERYResult = {
       _type: "customImage";
     } | null;
   } | null;
+} | null;
+// Source: ../frontend/app/queries/info-queries.ts
+// Variable: INFOPAGE_QUERY
+// Query: *[_type=="infopage" && language==$lang]{title, text, links[]->{..., slug}}[0]
+export type INFOPAGE_QUERYResult = {
+  title: string | null;
+  text: Array<{
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "customImage";
+    _key: string;
+  } | {
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }> | null;
+  links: Array<{
+    _id: string;
+    _type: "article";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    title?: string;
+    language?: string;
+    slug: Slug | null;
+    text?: Content;
+    image?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+    };
+    video?: MuxVideo;
+    event?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "event";
+    };
+    metaTitle?: MetaTitle;
+    metaDescription?: MetaDescription;
+  } | {
+    _id: string;
+    _type: "infopage";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    title?: string;
+    language?: string;
+    text?: Array<{
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "customImage";
+      _key: string;
+    } | {
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    }>;
+    links?: Array<{
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "article";
+    } | {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "infopage";
+    }>;
+    slug: null;
+  }> | null;
 } | null;


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.
- Refaktorering.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=766d46b3d30f448e9c6484c80098e715&pm=s

## Beskrivelse.
Informasjon er nå en singletonside. Vi vurderte om vi skulle gjøre det om til bare remix, siden det nok kommer til å være ganske statisk hva som skal være på siden, men endte med å gå for at det skal være en singleton page i sanity istedenfor, for at det skal være mer konsekvent. I tillegg kan det hende at noen artikler skal listes opp på info-siden, noe som gjør at det uansett er greit å ha det i sanity. La til ekstremt enkel sentrering av elementer.

## Skjermbilder.
![image](https://github.com/Fjaereheia/fjaereheia/assets/31958950/e44e599a-fe0e-4f37-8524-7fa75a3b31f3)
