### PR TITLE
URL Bug-fix on infopage.

### DIFF
--- a/frontend/app/routes/info._index.tsx
+++ b/frontend/app/routes/info._index.tsx
@@ -18,6 +18,16 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return json(informationPage);
 }
 
+function RedirectType(type: string) {
+  if (type == "article") {
+    return "/artikler";
+  } else if (type == "event") {
+    return "/event";
+  } else {
+    return "";
+  }
+}
+
 export default function Info() {
   const data = useLoaderData<typeof loader>() as INFOPAGE_QUERYResult;
   return (
@@ -25,7 +35,9 @@ export default function Info() {
       <h1 className="text-5xl font-bold mb-12">{data?.title}</h1>
       <div className="flex flex-col items-center font-normal gap-4 text-xl pt-12 pr-0 pl-0 pb-12">
         {data?.links?.map((link) => (
-          <Link to={`/${link.slug?.current}`}>{link.title || ""}</Link>
+          <Link to={`${RedirectType(link._type)}/${link.slug?.current}`}>
+            {link.title || ""}
+          </Link>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).

## Beskrivelse.
Fikset opp i bug på inforsiden. Tidligere ble URL feil når man trykket på Linken på infosiden. Det ble ikke lagt til sidetype i URL, kun slug. Fikset opp i det nå. 
Det er verdt å nevne at infosiden per nå ikke inneholder noen events, så funksjonen som er laget har noe kode som er overflødig. Men det kan være greit å beholde dersom andre sidetyper enn artikkel skal legges til på infoside ved et senere tidspunkt.    
## Skjermbilder.
