### PR TITLE
Added reviewType to RichTextEditor

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -326,6 +326,85 @@
     }
   },
   {
+    "name": "review",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "review"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "score": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "content": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "source": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "company": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "link": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "date": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "colorCombination",
     "type": "type",
     "value": {
@@ -786,6 +865,43 @@
               }
             },
             "dereferencesTo": "quote",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "review",
             "rest": {
               "type": "object",
               "attributes": {

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -11,8 +11,7 @@ import metaTitle from './objects/metaTitle'
 import metaDescription from './objects/metaDescription'
 import colorCombination from './objects/colorCombination'
 import roleGroups from './objects/roleGroups'
-import colorCombination from './objects/colorCombination'
-import roleGroups from './objects/roleGroups'
+import {reviewType} from './objects/reviewType'
 
 export const schemaTypes = [
   articleType,
@@ -28,4 +27,5 @@ export const schemaTypes = [
   metaTitle,
   metaDescription,
   colorCombination,
+  reviewType,
 ]

--- a/cms/schemaTypes/objects/RichTextEditor.ts
+++ b/cms/schemaTypes/objects/RichTextEditor.ts
@@ -15,5 +15,8 @@ export default {
     {
       type: 'quote',
     },
+    {
+      type: 'review',
+    },
   ],
 }

--- a/cms/schemaTypes/objects/reviewType.ts
+++ b/cms/schemaTypes/objects/reviewType.ts
@@ -1,0 +1,55 @@
+import {defineField, defineType} from 'sanity'
+
+export const reviewType = defineType({
+  name: 'review',
+  title: 'Anmeldelse',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'score',
+      type: 'number',
+      title: 'Score',
+      validation: (rule) => [rule.min(1).max(5).error(`Score må være mellom 1 og 5`)],
+    }),
+    defineField({
+      name: 'content',
+      type: 'text',
+      title: 'Innhold',
+      validation: (rule) => [
+        rule
+          .required()
+          .min(2)
+          .error(`Innhold er påkrevd for å poste et sitat, minimum lengde på 2 tegn`),
+        rule.required().max(100).warning(`Anbefaler kortere innhold.`),
+      ],
+    }),
+    defineField({
+      name: 'source',
+      type: 'string',
+      title: 'Kilde',
+      placeholder: 'e.g. Ola Nordmann',
+      validation: (rule) => [
+        rule
+          .required()
+          .min(2)
+          .error(`Kilde er påkrevd for å poste et sitat, minimum lengde på 2 tegn`),
+      ],
+    }),
+    defineField({
+      name: 'company',
+      type: 'string',
+      title: 'Selskap',
+      placeholder: 'e.g. Aftenposten',
+    }),
+    defineField({
+      name: 'link',
+      type: 'url',
+      title: 'Lenke til anmeldelse',
+    }),
+    defineField({
+      name: 'date',
+      type: 'datetime',
+      title: 'Dato for sitat',
+    }),
+  ],
+})


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Legge-til-anmeldelser-i-Sanity-b2cfe4f761474e459d8e5345ffba1932?pvs=4)

## Beskrivelse.
Man kan nå legge til en anmeldelse i RichTextEditor, veldig likt som sitat, men med mulighet til å legge til en score mellom 1-5 og en lenke til anmeldelse (valgfritt).

## Skjermbilder.
![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/170fade4-3261-4eb1-891b-5d13308d7f35)

![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/c2452b56-01b1-45e1-8914-17898c3b8a50)

![image](https://github.com/Fjaereheia/fjaereheia/assets/69513674/644515d1-3c2b-4065-8a78-302dc46066c7)
