### PR TITLE
Fix that root does not show error message on error

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -9,6 +9,7 @@ import {
   useLocation,
   json,
   useLoaderData,
+  useRouteLoaderData,
 } from "@remix-run/react";
 import "./styles/app.css";
 import StickyFooter from "./components/StickyFooter";
@@ -57,7 +58,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const { pathname } = useLocation();
-  const { language } = useLoaderData<typeof loader>();
+  const { language } = useRouteLoaderData<typeof loader>("root");
 
   let backgroundColorClass = "";
 
@@ -96,7 +97,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const { slideDirection, pathname } = usePageTransition();
-  const { language } = useLoaderData<typeof loader>();
+  const { language } = useRouteLoaderData<typeof loader>("root");
   return (
     <LanguageProvider language={language}>
       <motion.div


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).

## Beskrivelse
Fikset at error siden ikke viste korrekt på feil i root da det cascadet feil å bruke "useLoaderData" med errors.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/4200f899-4ea2-49c1-94fa-ba6a46429c32)
![image](https://github.com/user-attachments/assets/3df7c048-f12b-4ead-9b93-f43c853d1dca)

