### PR TITLE
Language sanity overview

### DIFF
--- a/cms/structure/index.ts
+++ b/cms/structure/index.ts
@@ -12,6 +12,30 @@ const SINGLETONS = [
   },
 ]
 
+const MULTI = [
+  {
+    id: 'article',
+    title: 'Artikler',
+    _type: 'document',
+    icon: DocumentTextIcon,
+    schemaType: 'article',
+  },
+  {
+    id: 'event',
+    title: 'Forestillinger',
+    _type: 'document',
+    icon: CalendarIcon,
+    schemaType: 'event',
+  },
+  {
+    id: 'role',
+    title: 'Roller',
+    _type: 'document',
+    icon: UserIcon,
+    schemaType: 'role',
+  },
+]
+
 const LANGUAGES = [
   {id: `nb`, title: `🇳🇴 Norwegian (Bokmål)`},
   {id: `en`, title: `🇬🇧 English`},
@@ -45,7 +69,27 @@ export const deskStructure = (S: StructureBuilder) =>
           ),
       ),
       S.divider(),
-      S.documentTypeListItem('article').title('Artikler').icon(DocumentTextIcon),
-      S.documentTypeListItem('event').title('Forestillinger').icon(CalendarIcon),
-      S.documentTypeListItem('role').title('Roller').icon(UserIcon),
+      ...MULTI.map((multi) =>
+        S.listItem()
+          .title(multi.title)
+          .id(multi.id)
+          .icon(multi.icon)
+          .child(
+            S.list()
+              .title(multi.title)
+              .id(multi.id)
+              .items([
+                ...LANGUAGES.map((language) =>
+                  S.listItem()
+                    .title(`${multi.title} (${language.id.toLocaleUpperCase()})`)
+                    .icon(multi.icon)
+                    .child(
+                      S.documentList()
+                        .title(`${language.id.toLocaleUpperCase()}`)
+                        .filter(`_type=="article" && language=="${language.id}"`),
+                    ),
+                ),
+              ]),
+          ),
+      ),
     ])

--- a/cms/structure/index.ts
+++ b/cms/structure/index.ts
@@ -44,6 +44,7 @@ export const deskStructure = (S: StructureBuilder) =>
               ),
           ),
       ),
+      S.divider(),
       S.documentTypeListItem('article').title('Artikler').icon(DocumentTextIcon),
       S.documentTypeListItem('event').title('Forestillinger').icon(CalendarIcon),
       S.documentTypeListItem('role').title('Roller').icon(UserIcon),


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.

## Linke til oppgave (Notion).
- https://www.notion.so/bekks/Kanban-9d75804e327947458fd2550b89b31775?p=d5b3fcf6f7924f878eb72e695b00984d&pm=s
## Beskrivelse.
- Oppdatert sanity for non-singleton pages. Nå vises språk i listen over dokumenter, og dokumentene filtrerer også basert på språk. 
## Skjermbilder.
<img width="1044" alt="Screenshot 2024-07-17 at 10 56 01" src="https://github.com/user-attachments/assets/f8b6c43c-1ccd-440d-acd7-395d76f8ceeb">
<-------------->
<img width="1083" alt="Screenshot 2024-07-17 at 10 57 25" src="https://github.com/user-attachments/assets/2b45cc03-f1ca-4ff8-9091-f2d1dc5cfd86">

<-------------->
<img width="1065" alt="Screenshot 2024-07-17 at 10 56 31" src="https://github.com/user-attachments/assets/953fd0db-6254-47a0-bc8b-94bba23b79aa">

