### PR TITLE
Working color combo

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -439,7 +439,7 @@
     }
   },
   {
-    "name": "colorCombinationNight",
+    "name": "colorCombinationsNight",
     "type": "type",
     "value": {
       "type": "union",
@@ -456,7 +456,7 @@
     }
   },
   {
-    "name": "colorCombinationDay",
+    "name": "colorCombinationsDay",
     "type": "type",
     "value": {
       "type": "union",
@@ -2905,11 +2905,11 @@
         },
         "optional": true
       },
-      "colorCombinationDay": {
+      "colorCombinationsDay": {
         "type": "objectAttribute",
         "value": {
           "type": "inline",
-          "name": "colorCombinationDay"
+          "name": "colorCombinationsDay"
         },
         "optional": true
       },
@@ -3133,11 +3133,11 @@
         },
         "optional": true
       },
-      "colorCombinationNight": {
+      "colorCombinationsNight": {
         "type": "objectAttribute",
         "value": {
           "type": "inline",
-          "name": "colorCombinationNight"
+          "name": "colorCombinationsNight"
         },
         "optional": true
       },

--- a/cms/schema.json
+++ b/cms/schema.json
@@ -439,18 +439,35 @@
     }
   },
   {
-    "name": "colorCombination",
+    "name": "colorCombinationNight",
     "type": "type",
     "value": {
       "type": "union",
       "of": [
         {
           "type": "string",
-          "value": "darkBluePrimaryGreenSecondary"
+          "value": "nightThemePurpleWhite"
         },
         {
           "type": "string",
-          "value": "lightRedPrimaryDarkBlueSecondary"
+          "value": "nightThemeBlueYellow"
+        }
+      ]
+    }
+  },
+  {
+    "name": "colorCombinationDay",
+    "type": "type",
+    "value": {
+      "type": "union",
+      "of": [
+        {
+          "type": "string",
+          "value": "dayThemeBlueBlack"
+        },
+        {
+          "type": "string",
+          "value": "dayThemePeachBlue"
         }
       ]
     }
@@ -2130,266 +2147,6 @@
         },
         "optional": true
       },
-      "text": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "union",
-            "of": [
-              {
-                "type": "object",
-                "attributes": {
-                  "children": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "marks": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "array",
-                              "of": {
-                                "type": "string"
-                              }
-                            },
-                            "optional": true
-                          },
-                          "text": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "span"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "style": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "normal"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h1"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h2"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h3"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h4"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h5"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h6"
-                        },
-                        {
-                          "type": "string",
-                          "value": "blockquote"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "listItem": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "bullet"
-                        },
-                        {
-                          "type": "string",
-                          "value": "number"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "markDefs": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "href": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "link"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "level": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "number"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "block"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "asset": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "sanity.imageAsset"
-                    },
-                    "optional": true
-                  },
-                  "hotspot": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageHotspot"
-                    },
-                    "optional": true
-                  },
-                  "crop": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageCrop"
-                    },
-                    "optional": true
-                  },
-                  "alt": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    },
-                    "optional": false
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "customImage"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "optional": true
-      },
       "links": {
         "type": "objectAttribute",
         "value": {
@@ -2884,61 +2641,41 @@
         "value": {
           "type": "array",
           "of": {
-            "type": "union",
-            "of": [
-              {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
-                },
-                "dereferencesTo": "article"
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
               },
-              {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
                 },
-                "dereferencesTo": "infopage"
+                "optional": true
               }
-            ]
+            },
+            "dereferencesTo": "article",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         },
         "optional": true
@@ -3168,11 +2905,11 @@
         },
         "optional": true
       },
-      "colorCombination": {
+      "colorCombinationDay": {
         "type": "objectAttribute",
         "value": {
           "type": "inline",
-          "name": "colorCombination"
+          "name": "colorCombinationDay"
         },
         "optional": true
       },
@@ -3396,11 +3133,11 @@
         },
         "optional": true
       },
-      "colorCombination": {
+      "colorCombinationNight": {
         "type": "objectAttribute",
         "value": {
           "type": "inline",
-          "name": "colorCombination"
+          "name": "colorCombinationNight"
         },
         "optional": true
       },

--- a/cms/schemaTypes/articleType.ts
+++ b/cms/schemaTypes/articleType.ts
@@ -31,9 +31,9 @@ export const articleType = defineType({
       hidden: true,
     }),
     defineField({
-      name: 'colorCombination',
+      name: 'colorCombinationDay',
       title: 'Fargekombinasjon',
-      type: 'colorCombination',
+      type: 'colorCombinationDay',
     }),
     defineField({
       name: 'slug',

--- a/cms/schemaTypes/articleType.ts
+++ b/cms/schemaTypes/articleType.ts
@@ -31,9 +31,9 @@ export const articleType = defineType({
       hidden: true,
     }),
     defineField({
-      name: 'colorCombinationDay',
+      name: 'colorCombinationsDay',
       title: 'Fargekombinasjon',
-      type: 'colorCombinationDay',
+      type: 'colorCombinationsDay',
     }),
     defineField({
       name: 'slug',

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -35,9 +35,9 @@ export const eventType = defineType({
       type: 'eventGenre',
     }),
     defineField({
-      name: 'colorCombination',
+      name: 'colorCombinationNight',
       title: 'Fargekombinasjon',
-      type: 'colorCombination',
+      type: 'colorCombinationNight',
     }),
     defineField({
       name: 'imageMask',

--- a/cms/schemaTypes/eventType.ts
+++ b/cms/schemaTypes/eventType.ts
@@ -35,9 +35,9 @@ export const eventType = defineType({
       type: 'eventGenre',
     }),
     defineField({
-      name: 'colorCombinationNight',
+      name: 'colorCombinationsNight',
       title: 'Fargekombinasjon',
-      type: 'colorCombinationNight',
+      type: 'colorCombinationsNight',
     }),
     defineField({
       name: 'imageMask',

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -9,13 +9,12 @@ import RichTextEditor from './objects/RichTextEditor'
 import {videoType} from '././objects/videoType'
 import metaTitle from './objects/metaTitle'
 import metaDescription from './objects/metaDescription'
-import colorCombination from './objects/colorCombination'
+import {colorCombinationDay, colorCombinationNight} from './objects/colorCombination'
 import imageMask from './objects/imageMask'
 import roleGroups from './objects/roleGroups'
 import {reviewType} from './objects/reviewType'
 import eventGenre from './objects/eventGenre'
 import {programpage} from './programpage'
-
 
 export const schemaTypes = [
   articleType,
@@ -30,7 +29,8 @@ export const schemaTypes = [
   videoType,
   metaTitle,
   metaDescription,
-  colorCombination,
+  colorCombinationDay,
+  colorCombinationNight,
   imageMask,
   reviewType,
   eventGenre,

--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -9,7 +9,7 @@ import RichTextEditor from './objects/RichTextEditor'
 import {videoType} from '././objects/videoType'
 import metaTitle from './objects/metaTitle'
 import metaDescription from './objects/metaDescription'
-import {colorCombinationDay, colorCombinationNight} from './objects/colorCombination'
+import {colorCombinationsDay, colorCombinationsNight} from './objects/colorCombination'
 import imageMask from './objects/imageMask'
 import roleGroups from './objects/roleGroups'
 import {reviewType} from './objects/reviewType'
@@ -29,8 +29,8 @@ export const schemaTypes = [
   videoType,
   metaTitle,
   metaDescription,
-  colorCombinationDay,
-  colorCombinationNight,
+  colorCombinationsDay,
+  colorCombinationsNight,
   imageMask,
   reviewType,
   eventGenre,

--- a/cms/schemaTypes/objects/colorCombination.ts
+++ b/cms/schemaTypes/objects/colorCombination.ts
@@ -1,8 +1,10 @@
 //These are temporary values, they will be replaced by the actual values from the design system
 
 const COLORCOMBINATION = [
-  {title: 'Mørk blå primær, grønn sekundær', value: 'darkBluePrimaryGreenSecondary'},
-  {title: 'Lys rød primær, mørk blå sekundær', value: 'lightRedPrimaryDarkBlueSecondary'},
+  {title: 'Lys blå primær, sort sekundær', value: 'dayThemeBlueBlack'},
+  {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlu'},
+  {title: 'Mørk lilla primær, hvit sekundær', value: 'nightThemePurpleWhite'},
+  {title: 'Mørk blå primær, gul sekundær', value: 'nightThemeBlueYellow'},
 ]
 const colorCombination = {
   name: 'colorCombination',

--- a/cms/schemaTypes/objects/colorCombination.ts
+++ b/cms/schemaTypes/objects/colorCombination.ts
@@ -1,14 +1,14 @@
 //These are temporary values, they will be replaced by the actual values from the design system
 
-const COLORCOMBINATION = [
+const COLORCOMBINATIONS = [
   {title: 'Lys blå primær, sort sekundær', value: 'dayThemeBlueBlack', theme: 'day'},
   {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlue', theme: 'day'},
   {title: 'Mørk lilla primær, hvit sekundær', value: 'nightThemePurpleWhite', theme: 'night'},
   {title: 'Mørk blå primær, gul sekundær', value: 'nightThemeBlueYellow', theme: 'night'},
 ]
 
-const dayThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'day')
-const nightThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'night')
+const dayThemes = COLORCOMBINATIONS.filter((theme) => theme.theme === 'day')
+const nightThemes = COLORCOMBINATIONS.filter((theme) => theme.theme === 'night')
 
 export const colorCombinationsDay = {
   name: 'colorCombinationsDay',

--- a/cms/schemaTypes/objects/colorCombination.ts
+++ b/cms/schemaTypes/objects/colorCombination.ts
@@ -1,20 +1,33 @@
 //These are temporary values, they will be replaced by the actual values from the design system
 
 const COLORCOMBINATION = [
-  {title: 'Lys blå primær, sort sekundær', value: 'dayThemeBlueBlack'},
-  {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlue'},
-  {title: 'Mørk lilla primær, hvit sekundær', value: 'nightThemePurpleWhite'},
-  {title: 'Mørk blå primær, gul sekundær', value: 'nightThemeBlueYellow'},
+  {title: 'Lys blå primær, sort sekundær', value: 'dayThemeBlueBlack', theme: 'day'},
+  {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlue', theme: 'day'},
+  {title: 'Mørk lilla primær, hvit sekundær', value: 'nightThemePurpleWhite', theme: 'night'},
+  {title: 'Mørk blå primær, gul sekundær', value: 'nightThemeBlueYellow', theme: 'night'},
 ]
-const colorCombination = {
-  name: 'colorCombination',
+
+const dayThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'day')
+const nightThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'night')
+
+export const colorCombinationDay = {
+  name: 'colorCombinationDay',
   title: 'Fargekombinasjon',
   type: 'string',
   options: {
-    list: COLORCOMBINATION.map(({title, value}) => ({title, value})),
+    list: dayThemes.map(({title, value}) => ({title, value})),
     layout: 'radio',
-    default: COLORCOMBINATION[0].value,
+    default: dayThemes[0].value,
   },
 }
 
-export default colorCombination
+export const colorCombinationNight = {
+  name: 'colorCombinationNight',
+  title: 'Fargekombinasjon',
+  type: 'string',
+  options: {
+    list: nightThemes.map(({title, value}) => ({title, value})),
+    layout: 'radio',
+    default: nightThemes[0].value,
+  },
+}

--- a/cms/schemaTypes/objects/colorCombination.ts
+++ b/cms/schemaTypes/objects/colorCombination.ts
@@ -10,8 +10,8 @@ const COLORCOMBINATION = [
 const dayThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'day')
 const nightThemes = COLORCOMBINATION.filter((theme) => theme.theme === 'night')
 
-export const colorCombinationDay = {
-  name: 'colorCombinationDay',
+export const colorCombinationsDay = {
+  name: 'colorCombinationsDay',
   title: 'Fargekombinasjon',
   type: 'string',
   options: {
@@ -21,8 +21,8 @@ export const colorCombinationDay = {
   },
 }
 
-export const colorCombinationNight = {
-  name: 'colorCombinationNight',
+export const colorCombinationsNight = {
+  name: 'colorCombinationsNight',
   title: 'Fargekombinasjon',
   type: 'string',
   options: {

--- a/cms/schemaTypes/objects/colorCombination.ts
+++ b/cms/schemaTypes/objects/colorCombination.ts
@@ -2,7 +2,7 @@
 
 const COLORCOMBINATION = [
   {title: 'Lys blå primær, sort sekundær', value: 'dayThemeBlueBlack'},
-  {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlu'},
+  {title: 'Lys orange primær, blå sekundær', value: 'dayThemePeachBlue'},
   {title: 'Mørk lilla primær, hvit sekundær', value: 'nightThemePurpleWhite'},
   {title: 'Mørk blå primær, gul sekundær', value: 'nightThemeBlueYellow'},
 ]

--- a/frontend/app/components/EventLabels.tsx
+++ b/frontend/app/components/EventLabels.tsx
@@ -13,6 +13,9 @@ type DateObject = {
 
 type Props = {
   dateObj: DateObject[];
+  primary?: string;
+  secondary?: string;
+  textColor?: string;
 };
 
 export function formatDateOnly(dateString: string): string {
@@ -21,7 +24,12 @@ export function formatDateOnly(dateString: string): string {
   return day[day.length - 1];
 }
 
-export const EventLabels = ({ dateObj }: Props) => {
+export const EventLabels = ({
+  dateObj,
+  primary,
+  secondary,
+  textColor,
+}: Props) => {
   const { language, t } = useTranslation();
 
   const renderLabel = () => {
@@ -36,7 +44,9 @@ export const EventLabels = ({ dateObj }: Props) => {
       <>
         <div className="m-4">
           <div className="m-1 flex gap-4">
-            <div className="p-1 border-2 border-gray-400">
+            <div
+              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+            >
               {dateObj.length === 1 ? (
                 formattedDate
               ) : (
@@ -46,15 +56,21 @@ export const EventLabels = ({ dateObj }: Props) => {
                 </>
               )}
             </div>
-            <div className="p-1 border-2 border-gray-400">
+            <div
+              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+            >
               {formattedTimestamp}
             </div>
           </div>
           <div className="m-1 flex gap-4">
-            <div className="p-1 border-2 border-gray-400">{t(texts.genre)}</div>
+            <div
+              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+            >
+              {t(texts.genre)}
+            </div>
             <button
               onClick={handleScroll}
-              className="border-2 pl-2 pr-2 border-gray-400 bg-slate-400 text-white"
+              className={`pl-2 pr-2 border-2 border-${secondary} bg-${secondary} text-${primary}`}
             >
               {t(texts.buyTicket)}
             </button>

--- a/frontend/app/components/EventLabels.tsx
+++ b/frontend/app/components/EventLabels.tsx
@@ -71,7 +71,7 @@ export const EventLabels = ({
               <div
                 className={`-mr-2 p-2 border ${textColorBorder} ${textColor}`}
               >
-                {genre}.toUpperCase()
+                {genre.toUpperCase()}
               </div>
             )}
 

--- a/frontend/app/components/EventLabels.tsx
+++ b/frontend/app/components/EventLabels.tsx
@@ -13,9 +13,11 @@ type DateObject = {
 
 type Props = {
   dateObj: DateObject[];
-  primary?: string;
-  secondary?: string;
+  primaryText?: string;
+  secondaryBgColor?: string;
+  secondaryBorder?: string;
   textColor?: string;
+  textColorBorder?: string;
 };
 
 export function formatDateOnly(dateString: string): string {
@@ -26,9 +28,11 @@ export function formatDateOnly(dateString: string): string {
 
 export const EventLabels = ({
   dateObj,
-  primary,
-  secondary,
+  primaryText,
+  secondaryBgColor,
+  secondaryBorder,
   textColor,
+  textColorBorder,
 }: Props) => {
   const { language, t } = useTranslation();
 
@@ -44,9 +48,7 @@ export const EventLabels = ({
       <>
         <div className="m-4">
           <div className="m-1 flex gap-4">
-            <div
-              className={`p-1 border-2 border-${textColor} text-${textColor}`}
-            >
+            <div className={`p-1 border-2 ${textColorBorder} ${textColor}`}>
               {dateObj.length === 1 ? (
                 formattedDate
               ) : (
@@ -56,21 +58,17 @@ export const EventLabels = ({
                 </>
               )}
             </div>
-            <div
-              className={`p-1 border-2 border-${textColor} text-${textColor}`}
-            >
+            <div className={`p-1 border-2 ${textColorBorder} ${textColor}`}>
               {formattedTimestamp}
             </div>
           </div>
           <div className="m-1 flex gap-4">
-            <div
-              className={`p-1 border-2 border-${textColor} text-${textColor}`}
-            >
+            <div className={`p-1 border-2 ${textColorBorder} ${textColor}`}>
               {t(texts.genre)}
             </div>
             <button
               onClick={handleScroll}
-              className={`pl-2 pr-2 border-2 border-${secondary} bg-${secondary}   text-${primary}`}
+              className={`pl-2 pr-2 border-2 ${secondaryBorder} ${secondaryBgColor}   ${primaryText}`}
             >
               {t(texts.buyTicket)}
             </button>

--- a/frontend/app/components/EventLabels.tsx
+++ b/frontend/app/components/EventLabels.tsx
@@ -45,7 +45,7 @@ export const EventLabels = ({
         <div className="m-4">
           <div className="m-1 flex gap-4">
             <div
-              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+              className={`p-1 border-2 border-${textColor} text-${textColor}`}
             >
               {dateObj.length === 1 ? (
                 formattedDate
@@ -57,20 +57,20 @@ export const EventLabels = ({
               )}
             </div>
             <div
-              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+              className={`p-1 border-2 border-${textColor} text-${textColor}`}
             >
               {formattedTimestamp}
             </div>
           </div>
           <div className="m-1 flex gap-4">
             <div
-              className={`p-1 border-2 border-${secondary} text-${textColor}`}
+              className={`p-1 border-2 border-${textColor} text-${textColor}`}
             >
               {t(texts.genre)}
             </div>
             <button
               onClick={handleScroll}
-              className={`pl-2 pr-2 border-2 border-${secondary} bg-${secondary} text-${primary}`}
+              className={`pl-2 pr-2 border-2 border-${secondary} bg-${secondary}   text-${primary}`}
             >
               {t(texts.buyTicket)}
             </button>

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -69,7 +69,9 @@ export default function PortableTextComponent({
   };
 
   return (
-    <div className="prose prose-h1:${textColor} prose-h2:${textColor}  ${textColor} font-serif font-normal text-base">
+    <div
+      className={`prose prose-h1:${textColor} prose-h2:${textColor}  ${textColor} font-serif font-normal text-base`}
+    >
       {textData && (
         <PortableText value={textData} components={customComponents} />
       )}

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -7,12 +7,12 @@ import ReviewComponent from "./ReviewComponent";
 
 interface PortableTextProps {
   textData: CustomContent;
-  textColor?: string;
+  textStyle?: string;
 }
 
 export default function PortableTextComponent({
   textData,
-  textColor,
+  textStyle,
 }: PortableTextProps) {
   const customComponents = {
     types: {
@@ -69,9 +69,7 @@ export default function PortableTextComponent({
   };
 
   return (
-    <div
-      className={`prose prose-h1:${textColor} prose-h2:${textColor}  ${textColor} font-serif font-normal text-base`}
-    >
+    <div className={`prose ${textStyle} font-serif font-normal text-base`}>
       {textData && (
         <PortableText value={textData} components={customComponents} />
       )}

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -7,9 +7,13 @@ import ReviewComponent from "./ReviewComponent";
 
 interface PortableTextProps {
   textData: CustomContent;
+  textColor?: string;
 }
 
-export default function PortableTextComponent({ textData }: PortableTextProps) {
+export default function PortableTextComponent({
+  textData,
+  textColor,
+}: PortableTextProps) {
   const customComponents = {
     types: {
       customImage: ({
@@ -65,7 +69,7 @@ export default function PortableTextComponent({ textData }: PortableTextProps) {
   };
 
   return (
-    <div className="prose">
+    <div className={`prose text-${textColor}`}>
       {textData && (
         <PortableText value={textData} components={customComponents} />
       )}

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -69,7 +69,7 @@ export default function PortableTextComponent({
   };
 
   return (
-    <div className={`prose ${textColor}`}>
+    <div className="prose prose-h1:${textColor} prose-h2:${textColor}  ${textColor} font-serif font-normal text-base">
       {textData && (
         <PortableText value={textData} components={customComponents} />
       )}

--- a/frontend/app/components/PortableTextComponent.tsx
+++ b/frontend/app/components/PortableTextComponent.tsx
@@ -69,7 +69,7 @@ export default function PortableTextComponent({
   };
 
   return (
-    <div className={`prose text-${textColor}`}>
+    <div className={`prose ${textColor}`}>
       {textData && (
         <PortableText value={textData} components={customComponents} />
       )}

--- a/frontend/app/components/QuoteComponent.tsx
+++ b/frontend/app/components/QuoteComponent.tsx
@@ -11,7 +11,7 @@ export default function QuoteComponent({
   };
 }) {
   return (
-    <blockquote className="border-none grid grid-flow-row place-items-center text-white text-center">
+    <blockquote className="border-none grid grid-flow-row place-items-center text-center">
       <img src={Quotes} alt="" />
       <span className="font-bold text-4xl">{quote.content}</span>
       <span className="not-italic">{quote.source}</span>

--- a/frontend/app/routes/($lang).artikler.$id.tsx
+++ b/frontend/app/routes/($lang).artikler.$id.tsx
@@ -45,7 +45,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export default function Article() {
   const data = useLoaderData<typeof loader>() as Custom_ARTICLE_QUERYResult;
-  const bgColor = getBackgroundColor(data?.colorCombinationDay);
+  const bgColor = getBackgroundColor(data?.colorCombinationsDay);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);
@@ -58,7 +58,7 @@ export default function Article() {
   return (
     <div
       className={`${getBackgroundColor(
-        data.colorCombinationDay
+        data.colorCombinationsDay
       )} min-h-screen flex flex-col items-center mx-6`}
     >
       <div className="flex flex-col items-center md:w-full lg:w-1/2">

--- a/frontend/app/routes/($lang).artikler.$id.tsx
+++ b/frontend/app/routes/($lang).artikler.$id.tsx
@@ -11,7 +11,6 @@ import { useBackgroundColor } from "~/utils/backgroundColor";
 import { useEffect } from "react";
 import { useTranslation } from "~/utils/i18n";
 
-
 export async function loader({ params }: LoaderFunctionArgs) {
   const article = await getArticle(params);
 
@@ -46,7 +45,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export default function Article() {
   const data = useLoaderData<typeof loader>() as Custom_ARTICLE_QUERYResult;
-  const bgColor = getBackgroundColor(data?.colorCombination);
+  const bgColor = getBackgroundColor(data?.colorCombinationDay);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);
@@ -57,7 +56,7 @@ export default function Article() {
     return <></>;
   }
   return (
-    <div className={getBackgroundColor(data.colorCombination)}>
+    <div className={getBackgroundColor(data.colorCombinationDay)}>
       <div className="flex flex-col items-center mx-6 mt- ">
         <div className="flex flex-col items-center md:w-full lg:w-1/2">
           <h1 className="text-4xl">{data.title}</h1>

--- a/frontend/app/routes/($lang).artikler.$id.tsx
+++ b/frontend/app/routes/($lang).artikler.$id.tsx
@@ -56,38 +56,34 @@ export default function Article() {
     return <></>;
   }
   return (
-
-       <div
+    <div
       className={`${getBackgroundColor(
         data.colorCombinationDay
       )} min-h-screen flex flex-col items-center mx-6`}
     >
-      <div className="flex flex-col items-center mx-6 mt- ">
-        <div className="flex flex-col items-center md:w-full lg:w-1/2">
-          <h1 className="text-4xl">{data.title}</h1>
-          {data.image && (
-            <img
-              className="w-3/4 md:w-3/4 lg:w-1/2"
-              src={urlFor(data.image.asset?._ref || "")}
-              alt={data.image.alt}
-            ></img>
-          )}
-          {data.video?.muxVideo.asset && (
-            <MuxPlayer
-              disableCookies={true}
-              playbackId={data.video.muxVideo.asset.playbackId}
-              title={data.video.title || ""}
-            />
-          )}
-          {data?.text && <PortableTextComponent textData={data.text} />}
-          {data?.event && (
-            <ButtonLink
-              url={`/event/${data.event?.slug?.current}`}
-              buttonText={t(texts.readMore)}
-            />
-          )}
-        </div>
-
+      <div className="flex flex-col items-center md:w-full lg:w-1/2">
+        <h1 className="text-4xl">{data.title}</h1>
+        {data.image && (
+          <img
+            className="w-3/4 md:w-3/4 lg:w-1/2"
+            src={urlFor(data.image.asset?._ref || "")}
+            alt={data.image.alt}
+          ></img>
+        )}
+        {data.video?.muxVideo.asset && (
+          <MuxPlayer
+            disableCookies={true}
+            playbackId={data.video.muxVideo.asset.playbackId}
+            title={data.video.title || ""}
+          />
+        )}
+        {data?.text && <PortableTextComponent textData={data.text} />}
+        {data?.event && (
+          <ButtonLink
+            url={`/event/${data.event?.slug?.current}`}
+            buttonText={t(texts.readMore)}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -58,7 +58,7 @@ export default function Event() {
     secondaryBorder,
     textColor,
     textColorBorder,
-  } = getColor(data?.colorCombination);
+  } = getColor(data?.colorCombinationNight);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -53,7 +53,6 @@ export default function Event() {
   const [viewScale, setViewScale] = useState(1);
   const {
     bgColor,
-    primaryBorder,
     primaryText,
     secondaryBgColor,
     secondaryBorder,

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -81,7 +81,7 @@ export default function Event() {
   }
   return (
     <div
-      className={` flex flex-col relative justify-center ${textColor} items-center`}
+      className={` flex flex-col relative justify-center ${textColor} items-center p-4`}
     >
       {data.image?.asset?._ref && (
         <ImageEventPage

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -66,6 +66,7 @@ export default function Event() {
   }, [setColor]);
   const { t } = useTranslation();
 
+  console.log(secondaryColor);
   useEffect(() => {
     const updateViewScale = () => {
       if (window.matchMedia("(min-width: 1024px)").matches) {
@@ -83,9 +84,7 @@ export default function Event() {
   }
   return (
     <div
-      className={`${getBackgroundColor(
-        data.colorCombination
-      )} flex flex-col relative justify-center items-center`}
+      className={`bg-${primaryColor} flex flex-col relative justify-center text-${textColor} items-center`}
     >
       {data.image?.asset?._ref && (
         <ImageEventPage
@@ -96,9 +95,7 @@ export default function Event() {
         />
       )}
       <div className="static">
-        <h1 className={`font-serif text-${textColor} text-2xl lg:text-4xl`}>
-          {data.title}
-        </h1>
+        <h1 className={`font-serif  text-2xl lg:text-4xl`}>{data.title}</h1>
       </div>
       {data.dates && (
         <EventLabels

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -59,7 +59,7 @@ export default function Event() {
     textColor,
     textColorBorder,
     portabletextStyle,
-  } = getColor(data?.colorCombinationNight);
+  } = getColor(data?.colorCombinationsNight);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);
@@ -83,7 +83,6 @@ export default function Event() {
   return (
     <div
       className={` in-h-screen flex flex-col relative justify-center ${textColor} items-center p-4`}
-
     >
       {data.image?.asset?._ref && (
         <ImageEventPage

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -2,12 +2,7 @@ import { useEffect, useState } from "react";
 import { LoaderFunctionArgs, json, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { EVENT_QUERYResult } from "sanity/types";
-import {
-  getBackgroundColor,
-  getSecondaryColor,
-  getPrimaryColor,
-  getTextColor,
-} from "~/utils/colorCombinations";
+import { getColor } from "~/utils/colorCombinations";
 import PortableTextComponent from "~/components/PortableTextComponent";
 import urlFor from "~/utils/imageUrlBuilder";
 import { Tickets } from "~/components/Tickets";
@@ -56,17 +51,20 @@ export default function Event() {
   const data = useLoaderData<typeof loader>() as EVENT_QUERYResult;
   const [openRole, setOpenRole] = useState(false);
   const [viewScale, setViewScale] = useState(1);
-  const bgColor = getBackgroundColor(data?.colorCombination);
-  const secondaryColor = getSecondaryColor(data?.colorCombination);
-  const primaryColor = getPrimaryColor(data?.colorCombination);
-  const textColor = getTextColor(data?.colorCombination);
+  const {
+    bgColor,
+    primaryBorder,
+    primaryText,
+    secondaryBgColor,
+    secondaryBorder,
+    textColor,
+    textColorBorder,
+  } = getColor(data?.colorCombination);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);
   }, [setColor]);
   const { t } = useTranslation();
-
-  console.log(secondaryColor);
   useEffect(() => {
     const updateViewScale = () => {
       if (window.matchMedia("(min-width: 1024px)").matches) {
@@ -84,7 +82,7 @@ export default function Event() {
   }
   return (
     <div
-      className={`bg-${primaryColor} flex flex-col relative justify-center text-${textColor} items-center`}
+      className={` flex flex-col relative justify-center ${textColor} items-center`}
     >
       {data.image?.asset?._ref && (
         <ImageEventPage
@@ -100,9 +98,11 @@ export default function Event() {
       {data.dates && (
         <EventLabels
           dateObj={data.dates}
-          primary={primaryColor}
-          secondary={secondaryColor}
+          primaryText={primaryText}
+          secondaryBgColor={secondaryBgColor}
+          secondaryBorder={secondaryBorder}
           textColor={textColor}
+          textColorBorder={textColorBorder}
         />
       )}
       {data.text && (

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from "react";
 import { LoaderFunctionArgs, json, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { EVENT_QUERYResult } from "sanity/types";
-import { getBackgroundColor } from "~/utils/colorCombinations";
+import {
+  getBackgroundColor,
+  getSecondaryColor,
+  getPrimaryColor,
+  getTextColor,
+} from "~/utils/colorCombinations";
 import PortableTextComponent from "~/components/PortableTextComponent";
 import urlFor from "~/utils/imageUrlBuilder";
 import { Tickets } from "~/components/Tickets";
@@ -52,6 +57,9 @@ export default function Event() {
   const [openRole, setOpenRole] = useState(false);
   const [viewScale, setViewScale] = useState(1);
   const bgColor = getBackgroundColor(data?.colorCombination);
+  const secondaryColor = getSecondaryColor(data?.colorCombination);
+  const primaryColor = getPrimaryColor(data?.colorCombination);
+  const textColor = getTextColor(data?.colorCombination);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
     setColor(bgColor);
@@ -88,10 +96,21 @@ export default function Event() {
         />
       )}
       <div className="static">
-        <h1 className="font-serif text-2xl lg:text-4xl">{data.title}</h1>
+        <h1 className={`font-serif text-${textColor} text-2xl lg:text-4xl`}>
+          {data.title}
+        </h1>
       </div>
-      {data.dates && <EventLabels dateObj={data.dates} />}
-      {data.text && <PortableTextComponent textData={data.text} />}
+      {data.dates && (
+        <EventLabels
+          dateObj={data.dates}
+          primary={primaryColor}
+          secondary={secondaryColor}
+          textColor={textColor}
+        />
+      )}
+      {data.text && (
+        <PortableTextComponent textData={data.text} textColor={textColor} />
+      )}
       {data.dates && <Tickets dateTickets={data.dates} />}
       {data.roleGroups && (
         <button

--- a/frontend/app/routes/($lang).event.$id.tsx
+++ b/frontend/app/routes/($lang).event.$id.tsx
@@ -58,6 +58,7 @@ export default function Event() {
     secondaryBorder,
     textColor,
     textColorBorder,
+    portabletextStyle,
   } = getColor(data?.colorCombinationNight);
   const { setColor } = useBackgroundColor();
   useEffect(() => {
@@ -106,7 +107,10 @@ export default function Event() {
         />
       )}
       {data.text && (
-        <PortableTextComponent textData={data.text} textColor={textColor} />
+        <PortableTextComponent
+          textData={data.text}
+          textStyle={portabletextStyle}
+        />
       )}
       {data.dates && <Tickets dateTickets={data.dates} />}
       {data.roleGroups && (

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -2,7 +2,7 @@ export function getBackgroundColor(colorCombination: string | undefined) {
   switch (colorCombination) {
     case "dayThemeBlueBlack":
       return "bg-dayThemeBlueBlack-primary";
-    case "dayThemePeachBlu":
+    case "dayThemePeachBlue":
       return "bg-dayThemePeachBlue-primary";
     case "nightThemePurpleWhite":
       return "bg-nightThemePurpleWhite-primary";
@@ -16,25 +16,44 @@ export function getBackgroundColor(colorCombination: string | undefined) {
 export function getSecondaryColor(colorCombination: string | undefined) {
   switch (colorCombination) {
     case "dayThemeBlueBlack":
-      return "bg-dayThemeBlueBlack-secondary";
-    case "dayThemePeachBlu":
+      return "dayThemeBlueBlack-secondary";
+    case "dayThemePeachBlue":
       return "dayThemePeachBlu-secondary";
     case "nightThemePurpleWhite":
-      return "bg-nightThemePurpleWhite-secondary";
+      return "nightThemePurpleWhite-secondary";
     case "nightThemeBlueYellow":
-      return "bg-nightThemeBlueYellow-secondary";
+      return "nightThemeBlueYellow-secondary";
     default:
-      return "bg-white";
+      return "white";
+  }
+}
+
+export function getPrimaryColor(colorCombination: string | undefined) {
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "dayThemeBlueBlack-primary";
+    case "dayThemePeachBlue":
+      return "dayThemePeachBlu-primary";
+    case "nightThemePurpleWhite":
+      return "nightThemePurpleWhite-primary";
+    case "nightThemeBlueYellow":
+      return "nightThemeBlueYellow-primary";
+    default:
+      return "white";
   }
 }
 
 export function getTextColor(colorCombination: string | undefined) {
   switch (colorCombination) {
-    case "lightRedPrimaryDarkBlueSecondary":
-      return "text-black";
-    case "darkBluePrimaryGreenSecondary":
-      return "text-white";
+    case "dayThemeBlueBlack":
+      return "black";
+    case "dayThemePeachBlue":
+      return "black";
+    case "nightThemePurpleWhite":
+      return "white";
+    case "nightThemeBlueYellow":
+      return "white";
     default:
-      return "bg-black";
+      return "black";
   }
 }

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -1,9 +1,13 @@
 export function getBackgroundColor(colorCombination: string | undefined) {
   switch (colorCombination) {
-    case "lightRedPrimaryDarkBlueSecondary":
-      return "bg-lightRedPrimaryDarkBlueSecondary-primary";
-    case "darkBluePrimaryGreenSecondary":
-      return "bg-darkBluePrimaryGreenSecondary-primary";
+    case "dayThemeBlueBlack":
+      return "bg-dayThemeBlueBlack-primary";
+    case "dayThemePeachBlu":
+      return "bg-dayThemePeachBlue-primary";
+    case "nightThemePurpleWhite":
+      return "bg-nightThemePurpleWhite-primary";
+    case "nightThemeBlueYellow":
+      return "bg-nightThemeBlueYellow-primary";
     default:
       return "bg-white";
   }
@@ -11,10 +15,14 @@ export function getBackgroundColor(colorCombination: string | undefined) {
 
 export function getSecondaryColor(colorCombination: string | undefined) {
   switch (colorCombination) {
-    case "lightRedPrimaryDarkBlueSecondary":
-      return "lightRedPrimaryDarkBlueSecondary-secondary";
-    case "darkBluePrimaryGreenSecondary":
-      return "darkBluePrimaryGreenSecondary-secondary";
+    case "dayThemeBlueBlack":
+      return "bg-dayThemeBlueBlack-secondary";
+    case "dayThemePeachBlu":
+      return "dayThemePeachBlu-secondary";
+    case "nightThemePurpleWhite":
+      return "bg-nightThemePurpleWhite-secondary";
+    case "nightThemeBlueYellow":
+      return "bg-nightThemeBlueYellow-secondary";
     default:
       return "bg-white";
   }

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -1,47 +1,76 @@
 export function getBackgroundColor(colorCombination: string | undefined) {
-  if (colorCombination) {
-    const style = "bg-" + colorCombination + "-primary";
-    return style;
-  } else {
-    return "bg-white";
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "bg-dayThemeBlueBlack-primary";
+    case "dayThemePeachBlue":
+      return "bg-dayThemePeachBlue-primary";
+    case "nightThemePurpleWhite":
+      return "bg-nightThemePurpleWhite-primary";
+    case "nightThemeBlueYellow":
+      return "bg-nightThemeBlueYellow-primary";
+    default:
+      return "bg-white";
   }
 }
 
 export function getPrimaryBorderColor(colorCombination: string | undefined) {
-  if (colorCombination) {
-    const style = "border-" + colorCombination + "-primary";
-    return style;
-  } else {
-    return "border-white";
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "border-dayThemeBlueBlack-primary";
+    case "dayThemePeachBlue":
+      return "border-dayThemePeachBlue-primary";
+    case "nightThemePurpleWhite":
+      return "border-nightThemePurpleWhite-primary";
+    case "nightThemeBlueYellow":
+      return "border-nightThemeBlueYellow-primary";
+    default:
+      return "border-white";
   }
 }
 
 export function getPrimaryTextColor(colorCombination: string | undefined) {
-  if (colorCombination) {
-    const style = "text-" + colorCombination + "-primary";
-    return style;
-  } else {
-    return "text-white";
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "text-dayThemeBlueBlack-primary";
+    case "dayThemePeachBlue":
+      return "text-dayThemePeachBlue-primary";
+    case "nightThemePurpleWhite":
+      return "text-nightThemePurpleWhite-primary";
+    case "nightThemeBlueYellow":
+      return "text-nightThemeBlueYellow-primary";
+    default:
+      return "text-white";
   }
 }
 
 export function getSecondaryBackgroundColor(
   colorCombination: string | undefined
 ) {
-  if (colorCombination) {
-    const style = "bg-" + colorCombination + "-secondary";
-    return style;
-  } else {
-    return "bg-white";
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "bg-dayThemeBlueBlack-secondary";
+    case "dayThemePeachBlue":
+      return "bg-dayThemePeachBlue-secondary";
+    case "nightThemePurpleWhite":
+      return "bg-nightThemePurpleWhite-secondary";
+    case "nightThemeBlueYellow":
+      return "bg-nightThemeBlueYellow-secondary";
+    default:
+      return "bg-white";
   }
 }
-
 export function getSecondaryBorderColor(colorCombination: string | undefined) {
-  if (colorCombination) {
-    const style = "border-" + colorCombination + "-secondary";
-    return style;
-  } else {
-    return "border-white";
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "border-dayThemeBlueBlack-secondary";
+    case "dayThemePeachBlue":
+      return "border-dayThemePeachBlue-secondary";
+    case "nightThemePurpleWhite":
+      return "border-nightThemePurpleWhite-secondary";
+    case "nightThemeBlueYellow":
+      return "border-nightThemeBlueYellow-secondary";
+    default:
+      return "border-white";
   }
 }
 

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -1,59 +1,88 @@
 export function getBackgroundColor(colorCombination: string | undefined) {
-  switch (colorCombination) {
-    case "dayThemeBlueBlack":
-      return "bg-dayThemeBlueBlack-primary";
-    case "dayThemePeachBlue":
-      return "bg-dayThemePeachBlue-primary";
-    case "nightThemePurpleWhite":
-      return "bg-nightThemePurpleWhite-primary";
-    case "nightThemeBlueYellow":
-      return "bg-nightThemeBlueYellow-primary";
-    default:
-      return "bg-white";
+  if (colorCombination) {
+    const style = "bg-" + colorCombination + "-primary";
+    return style;
+  } else {
+    return "bg-white";
   }
 }
 
-export function getSecondaryColor(colorCombination: string | undefined) {
-  switch (colorCombination) {
-    case "dayThemeBlueBlack":
-      return "dayThemeBlueBlack-secondary";
-    case "dayThemePeachBlue":
-      return "dayThemePeachBlue-secondary";
-    case "nightThemePurpleWhite":
-      return "nightThemePurpleWhite-secondary";
-    case "nightThemeBlueYellow":
-      return "nightThemeBlueYellow-secondary";
-    default:
-      return "white";
+export function getPrimaryBorderColor(colorCombination: string | undefined) {
+  if (colorCombination) {
+    const style = "border-" + colorCombination + "-primary";
+    return style;
+  } else {
+    return "border-white";
   }
 }
 
-export function getPrimaryColor(colorCombination: string | undefined) {
-  switch (colorCombination) {
-    case "dayThemeBlueBlack":
-      return "dayThemeBlueBlack-primary";
-    case "dayThemePeachBlue":
-      return "dayThemePeachBlue-primary";
-    case "nightThemePurpleWhite":
-      return "nightThemePurpleWhite-primary";
-    case "nightThemeBlueYellow":
-      return "nightThemeBlueYellow-primary";
-    default:
-      return "white";
+export function getPrimaryTextColor(colorCombination: string | undefined) {
+  if (colorCombination) {
+    const style = "text-" + colorCombination + "-primary";
+    return style;
+  } else {
+    return "text-white";
+  }
+}
+
+export function getSecondaryBackgroundColor(
+  colorCombination: string | undefined
+) {
+  if (colorCombination) {
+    const style = "bg-" + colorCombination + "-secondary";
+    return style;
+  } else {
+    return "bg-white";
+  }
+}
+
+export function getSecondaryBorderColor(colorCombination: string | undefined) {
+  if (colorCombination) {
+    const style = "border-" + colorCombination + "-secondary";
+    return style;
+  } else {
+    return "border-white";
   }
 }
 
 export function getTextColor(colorCombination: string | undefined) {
   switch (colorCombination) {
     case "dayThemeBlueBlack":
-      return "black";
+      return "text-black";
     case "dayThemePeachBlue":
-      return "black";
+      return "text-black";
     case "nightThemePurpleWhite":
-      return "white";
+      return "text-white";
     case "nightThemeBlueYellow":
-      return "white";
+      return "text-white";
     default:
-      return "black";
+      return "text-black";
   }
+}
+
+export function getTextColorBorder(colorCombination: string | undefined) {
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "border-black";
+    case "dayThemePeachBlue":
+      return "border-black";
+    case "nightThemePurpleWhite":
+      return "border-white";
+    case "nightThemeBlueYellow":
+      return "border-white";
+    default:
+      return "border-black";
+  }
+}
+
+export function getColor(colorCombination: string | undefined) {
+  return {
+    bgColor: getBackgroundColor(colorCombination),
+    primaryBorder: getPrimaryBorderColor(colorCombination),
+    primaryText: getPrimaryTextColor(colorCombination),
+    secondaryBgColor: getSecondaryBackgroundColor(colorCombination),
+    secondaryBorder: getSecondaryBorderColor(colorCombination),
+    textColor: getTextColor(colorCombination),
+    textColorBorder: getTextColorBorder(colorCombination),
+  };
 }

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -104,6 +104,21 @@ export function getTextColorBorder(colorCombination: string | undefined) {
   }
 }
 
+export function getPortabletextStyle(colorCombination: string | undefined) {
+  switch (colorCombination) {
+    case "dayThemeBlueBlack":
+      return "prose-h1:text-black prose-h2:text-black text-black";
+    case "dayThemePeachBlue":
+      return "prose-h1:text-black prose-h2:text-black text-black";
+    case "nightThemePurpleWhite":
+      return "prose-h1:text-white prose-h2:text-white text-white";
+    case "nightThemeBlueYellow":
+      return "prose-h1:text-white prose-h2:text-white text-white";
+    default:
+      return "prose-h1:text-black prose-h2:text-black text-black";
+  }
+}
+
 export function getColor(colorCombination: string | undefined) {
   return {
     bgColor: getBackgroundColor(colorCombination),
@@ -113,5 +128,6 @@ export function getColor(colorCombination: string | undefined) {
     secondaryBorder: getSecondaryBorderColor(colorCombination),
     textColor: getTextColor(colorCombination),
     textColorBorder: getTextColorBorder(colorCombination),
+    portabletextStyle: getPortabletextStyle(colorCombination),
   };
 }

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -18,7 +18,7 @@ export function getSecondaryColor(colorCombination: string | undefined) {
     case "dayThemeBlueBlack":
       return "dayThemeBlueBlack-secondary";
     case "dayThemePeachBlue":
-      return "dayThemePeachBlu-secondary";
+      return "dayThemePeachBlue-secondary";
     case "nightThemePurpleWhite":
       return "nightThemePurpleWhite-secondary";
     case "nightThemeBlueYellow":
@@ -33,7 +33,7 @@ export function getPrimaryColor(colorCombination: string | undefined) {
     case "dayThemeBlueBlack":
       return "dayThemeBlueBlack-primary";
     case "dayThemePeachBlue":
-      return "dayThemePeachBlu-primary";
+      return "dayThemePeachBlue-primary";
     case "nightThemePurpleWhite":
       return "nightThemePurpleWhite-primary";
     case "nightThemeBlueYellow":

--- a/frontend/app/utils/colorCombinations.ts
+++ b/frontend/app/utils/colorCombinations.ts
@@ -107,13 +107,13 @@ export function getTextColorBorder(colorCombination: string | undefined) {
 export function getPortabletextStyle(colorCombination: string | undefined) {
   switch (colorCombination) {
     case "dayThemeBlueBlack":
-      return "prose-h1:text-black prose-h2:text-black text-black";
+      return "prose-h1:text-black prose-h2:text-dayThemeBlueBlack-secondary text-black";
     case "dayThemePeachBlue":
-      return "prose-h1:text-black prose-h2:text-black text-black";
+      return "prose-h1:text-black prose-h2:text-dayThemePeachBlue-secondary text-black";
     case "nightThemePurpleWhite":
-      return "prose-h1:text-white prose-h2:text-white text-white";
+      return "prose-h1:text-white prose-h2:text-nightThemePurpleWhite-secondary text-white";
     case "nightThemeBlueYellow":
-      return "prose-h1:text-white prose-h2:text-white text-white";
+      return "prose-h1:text-white prose-h2:text-nightThemeBlueYellow-secondary text-white";
     default:
       return "prose-h1:text-black prose-h2:text-black text-black";
   }

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -86,9 +86,9 @@ export type Review = {
 
 export type ImageMask = "smallImageNotCoveringScreen" | "bigImageCoveringScreen";
 
-export type ColorCombinationNight = "nightThemePurpleWhite" | "nightThemeBlueYellow";
+export type ColorCombinationsNight = "nightThemePurpleWhite" | "nightThemeBlueYellow";
 
-export type ColorCombinationDay = "dayThemeBlueBlack" | "dayThemePeachBlue";
+export type ColorCombinationsDay = "dayThemeBlueBlack" | "dayThemePeachBlue";
 
 export type MetaDescription = string;
 
@@ -488,7 +488,7 @@ export type Article = {
   _rev: string;
   title: string;
   language?: string;
-  colorCombinationDay?: ColorCombinationDay;
+  colorCombinationsDay?: ColorCombinationsDay;
   slug?: Slug;
   text?: Content;
   image?: {
@@ -528,7 +528,7 @@ export type Event = {
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombinationNight?: ColorCombinationNight;
+  colorCombinationsNight?: ColorCombinationsNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -587,7 +587,7 @@ export type InternationalizedArrayReference = Array<{
   _key: string;
 } & InternationalizedArrayReferenceValue>;
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombinationNight | ColorCombinationDay | MetaDescription | MetaTitle | Video | RoleGroups | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Role | Infopage | Frontpage | Article | Event | Document | CustomImage | Slug | InternationalizedArrayReference;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombinationsNight | ColorCombinationsDay | MetaDescription | MetaTitle | Video | RoleGroups | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Role | Infopage | Frontpage | Article | Event | Document | CustomImage | Slug | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../frontend/app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -600,7 +600,7 @@ export type ARTICLES_QUERYResult = Array<{
   _rev: string;
   title: string;
   language?: string;
-  colorCombinationDay?: ColorCombinationDay;
+  colorCombinationsDay?: ColorCombinationsDay;
   slug?: Slug;
   text?: Content;
   image?: {
@@ -640,7 +640,7 @@ export type ARTICLE_QUERYResult = {
   _rev: string;
   title: string;
   language?: string;
-  colorCombinationDay?: ColorCombinationDay;
+  colorCombinationsDay?: ColorCombinationsDay;
   slug?: Slug;
   text: Array<{
     _ref: string;
@@ -699,7 +699,7 @@ export type ARTICLE_QUERYResult = {
     title: string;
     language?: string;
     eventGenre?: EventGenre;
-    colorCombinationNight?: ColorCombinationNight;
+    colorCombinationsNight?: ColorCombinationsNight;
     imageMask?: ImageMask;
     slug?: Slug;
     preamble?: string;
@@ -743,7 +743,7 @@ export type EVENTS_QUERYResult = Array<{
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombinationNight?: ColorCombinationNight;
+  colorCombinationsNight?: ColorCombinationsNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -783,7 +783,7 @@ export type EVENT_QUERYResult = {
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombinationNight?: ColorCombinationNight;
+  colorCombinationsNight?: ColorCombinationsNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -913,7 +913,7 @@ export type INFOPAGE_QUERYResult = {
     _rev: string;
     title: string;
     language?: string;
-    colorCombinationDay?: ColorCombinationDay;
+    colorCombinationsDay?: ColorCombinationsDay;
     slug: Slug | null;
     text?: Content;
     image?: {

--- a/frontend/sanity/types.ts
+++ b/frontend/sanity/types.ts
@@ -86,7 +86,9 @@ export type Review = {
 
 export type ImageMask = "smallImageNotCoveringScreen" | "bigImageCoveringScreen";
 
-export type ColorCombination = "darkBluePrimaryGreenSecondary" | "lightRedPrimaryDarkBlueSecondary";
+export type ColorCombinationNight = "nightThemePurpleWhite" | "nightThemeBlueYellow";
+
+export type ColorCombinationDay = "dayThemeBlueBlack" | "dayThemePeachBlue";
 
 export type MetaDescription = string;
 
@@ -367,36 +369,6 @@ export type Programpage = {
   _rev: string;
   title: string;
   language?: string;
-  text?: Array<{
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    alt: string;
-    _type: "customImage";
-    _key: string;
-  }>;
   links?: Array<{
     _ref: string;
     _type: "reference";
@@ -472,12 +444,8 @@ export type Infopage = {
     _ref: string;
     _type: "reference";
     _weak?: boolean;
+    _key: string;
     [internalGroqTypeReferenceTo]?: "article";
-  } | {
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    [internalGroqTypeReferenceTo]?: "infopage";
   }>;
 };
 
@@ -520,7 +488,7 @@ export type Article = {
   _rev: string;
   title: string;
   language?: string;
-  colorCombination?: ColorCombination;
+  colorCombinationDay?: ColorCombinationDay;
   slug?: Slug;
   text?: Content;
   image?: {
@@ -560,7 +528,7 @@ export type Event = {
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombination?: ColorCombination;
+  colorCombinationNight?: ColorCombinationNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -619,8 +587,7 @@ export type InternationalizedArrayReference = Array<{
   _key: string;
 } & InternationalizedArrayReferenceValue>;
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombination | MetaDescription | MetaTitle | Video | RoleGroups | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Role | Infopage | Frontpage | Article | Event | Document | CustomImage | Slug | InternationalizedArrayReference;
-
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | EventGenre | Review | ImageMask | ColorCombinationNight | ColorCombinationDay | MetaDescription | MetaTitle | Video | RoleGroups | Content | Quote | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | MuxVideo | MuxVideoAsset | MuxAssetData | MuxStaticRenditions | MuxStaticRenditionFile | MuxPlaybackId | MuxTrack | TranslationMetadata | InternationalizedArrayReferenceValue | Programpage | Role | Infopage | Frontpage | Article | Event | Document | CustomImage | Slug | InternationalizedArrayReference;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../frontend/app/queries/article-queries.ts
 // Variable: ARTICLES_QUERY
@@ -633,7 +600,7 @@ export type ARTICLES_QUERYResult = Array<{
   _rev: string;
   title: string;
   language?: string;
-  colorCombination?: ColorCombination;
+  colorCombinationDay?: ColorCombinationDay;
   slug?: Slug;
   text?: Content;
   image?: {
@@ -673,7 +640,7 @@ export type ARTICLE_QUERYResult = {
   _rev: string;
   title: string;
   language?: string;
-  colorCombination?: ColorCombination;
+  colorCombinationDay?: ColorCombinationDay;
   slug?: Slug;
   text: Array<{
     _ref: string;
@@ -732,7 +699,7 @@ export type ARTICLE_QUERYResult = {
     title: string;
     language?: string;
     eventGenre?: EventGenre;
-    colorCombination?: ColorCombination;
+    colorCombinationNight?: ColorCombinationNight;
     imageMask?: ImageMask;
     slug?: Slug;
     preamble?: string;
@@ -776,7 +743,7 @@ export type EVENTS_QUERYResult = Array<{
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombination?: ColorCombination;
+  colorCombinationNight?: ColorCombinationNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -816,7 +783,7 @@ export type EVENT_QUERYResult = {
   title: string;
   language?: string;
   eventGenre?: EventGenre;
-  colorCombination?: ColorCombination;
+  colorCombinationNight?: ColorCombinationNight;
   imageMask?: ImageMask;
   slug?: Slug;
   preamble?: string;
@@ -946,7 +913,7 @@ export type INFOPAGE_QUERYResult = {
     _rev: string;
     title: string;
     language?: string;
-    colorCombination?: ColorCombination;
+    colorCombinationDay?: ColorCombinationDay;
     slug: Slug | null;
     text?: Content;
     image?: {
@@ -975,56 +942,6 @@ export type INFOPAGE_QUERYResult = {
     };
     metaTitle: MetaTitle;
     metaDescription: MetaDescription;
-  } | {
-    _id: string;
-    _type: "infopage";
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    title: string;
-    language?: string;
-    text?: Array<{
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      alt: string;
-      _type: "customImage";
-      _key: string;
-    } | {
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: "span";
-        _key: string;
-      }>;
-      style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-      listItem?: "bullet" | "number";
-      markDefs?: Array<{
-        href?: string;
-        _type: "link";
-        _key: string;
-      }>;
-      level?: number;
-      _type: "block";
-      _key: string;
-    }>;
-    links?: Array<{
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "article";
-    } | {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "infopage";
-    }>;
-    slug: null;
   }> | null;
 } | null;
 // Source: ../frontend/app/queries/program-queries.ts
@@ -1032,36 +949,7 @@ export type INFOPAGE_QUERYResult = {
 // Query: *[_type=="programpage" && language==$lang]{title, text, links[]->{title, slug}}[0]
 export type PROGRAMPAGE_QUERYResult = {
   title: string;
-  text: Array<{
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    alt: string;
-    _type: "customImage";
-    _key: string;
-  } | {
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  }> | null;
+  text: null;
   links: Array<{
     title: string;
     slug: Slug | null;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,17 +4,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        lightRedPrimaryDarkBlueSecondary: {
-          primary: "#FF4D4D",
-          secondary: "#182E39",
-        },
-        darkBluePrimaryGreenSecondary: {
-          primary: "#182E39",
-          secondary: "#D4FF26",
-        },
         dayThemeBlueBlack: {
           primary: "#B6E3FD",
-          secondary: "black",
+          secondary: "#000000",
         },
         dayThemePeachBlue: {
           primary: "#FFD3CE",
@@ -22,7 +14,7 @@ export default {
         },
         nightThemePurpleWhite: {
           primary: "#556090",
-          secondary: "white",
+          secondary: "#FFFFFF",
         },
         nightThemeBlueYellow: {
           primary: "#182E39",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -12,6 +12,22 @@ export default {
           primary: "#182E39",
           secondary: "#D4FF26",
         },
+        dayThemeBlueBlack: {
+          primary: "#B6E3FD",
+          secondary: "black",
+        },
+        dayThemePeachBlue: {
+          primary: "#FFD3CE",
+          secondary: "#350E94",
+        },
+        nightThemePurpleWhite: {
+          primary: "#556090",
+          secondary: "white",
+        },
+        nightThemeBlueYellow: {
+          primary: "#182E39",
+          secondary: "#D4FF26",
+        },
         newsletter: "#59A1B6",
         lightblue: "#83D2FF",
       },


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.


## Linke til oppgave (Notion).
https://www.notion.so/bekks/Bruk-fargepallett-fra-Nosleep-til-farger-for-bakgrunn-tekst-og-komponenter-956e8a9898f54ff3a031d5085f42e8fc?pvs=4
## Beskrivelse.
Lagt til to fargekombinajsoner for dag og natt tema:
- Dag: artikler
- Natt: forestillinger
- Vanskelig å komprimere tailwind stylingen, da tailwind bare godkjenner fullstendige strenger definert fra start
## Skjermbilder.
