### PR TITLE
Fixed error page not showing on error

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -6,9 +6,8 @@ import {
   ScrollRestoration,
   useRouteError,
   redirect,
-  useLocation,
-  json,
   useRouteLoaderData,
+  json,
 } from "@remix-run/react";
 import "./styles/app.css";
 import StickyFooter from "./components/StickyFooter";
@@ -17,7 +16,11 @@ import PageNotFound from "./components/PageNotFound";
 import { LoaderFunction } from "@remix-run/node";
 import { motion } from "framer-motion";
 import { usePageTransition } from "./utils/pageTransition";
-import { getLanguageFromPath, LanguageProvider } from "./utils/i18n";
+import {
+  getLanguageFromPath,
+  LanguageProvider,
+  useTranslation,
+} from "./utils/i18n";
 import {
   BackgroundColorProvider,
   useBackgroundColor,
@@ -31,6 +34,7 @@ type ErrorWithStatus = {
 
 export function ErrorBoundary() {
   const error = useRouteError() as ErrorWithStatus;
+  console.error(error);
 
   return (
     <>
@@ -59,14 +63,12 @@ export const loader: LoaderFunction = async ({ request }) => {
   if (pathname.endsWith("/") && pathname.length > 1) {
     throw redirect(`${pathname.slice(0, -1)}${search}`, 301);
   }
-
   const language = getLanguageFromPath(pathname);
   return json({ language });
 };
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  const { pathname } = useLocation();
-  const { language } = useRouteLoaderData<typeof loader>("root");
+  const { language } = useTranslation();
   const { color } = useBackgroundColor();
 
   return (

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -31,7 +31,6 @@ type ErrorWithStatus = {
 
 export function ErrorBoundary() {
   const error = useRouteError() as ErrorWithStatus;
-  console.debug(error);
 
   return (
     <>

--- a/frontend/app/utils/i18n/index.tsx
+++ b/frontend/app/utils/i18n/index.tsx
@@ -1,5 +1,6 @@
 //Inspired by @vygruppen/spor-react i18n package
 
+import { useLocation } from "@remix-run/react";
 import React, { createContext, useContext } from "react";
 
 export enum Language {
@@ -47,7 +48,7 @@ export function LanguageProvider({
  * @internal
  */
 function useLanguage() {
-  const language = useContext(LanguageContext);
+  const language = getLanguageFromPath(useLocation().pathname);
   if (!language) {
     throw new Error("Please wrap your application in a LanguageProvider");
   }


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Fikse-at-Error-page-ikke-renderer-grunnet-spr-k-cfb34107dddf457bab9e9849ba043cc1?pvs=4)

## Beskrivelse.
Fikset at Remix kræsjet på error og ike viste PageNotFound.tsx. Dette var fordi i18n index.tsx prøvde å lese context som ikke er definert, nå henter den alltid språk fra path.

## Skjermbilder.
<img width="1777" alt="image" src="https://github.com/user-attachments/assets/c59e03cd-a44a-4118-9dba-cdb90ac6ab5b">

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/66b14f95-ac7c-484c-9a0c-9f0e017064ef">
