### PR TITLE
Update roledropdown

### DIFF
--- a/frontend/app/components/RoleDropDown.tsx
+++ b/frontend/app/components/RoleDropDown.tsx
@@ -70,12 +70,12 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
             key={index}
             initial={{ height: 0, opacity: 0 }}
             animate={{
-              display: openRoleStates[index] ? "block" : "none",
               height: openRoleStates[index] ? "auto" : 0,
               opacity: openRoleStates[index] ? 1 : 0,
             }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 1.0 }}
+            style={{ overflow: "hidden" }}
           >
             <div id={index.toString()} className="m-4 mb-10">
               {roleGroup.roles?.map((role, roleIndex) => (

--- a/frontend/app/components/RoleDropDown.tsx
+++ b/frontend/app/components/RoleDropDown.tsx
@@ -29,54 +29,58 @@ interface RoleDropDownProps {
       } | null;
       text: string | null;
     }> | null;
-  }> | null;
+  }>;
 }
 
 export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
   const { t } = useTranslation();
-  const [openRole, setOpenRole] = useState(false);
+  const [openRoleStates, setOpenRoleStates] = useState(
+    Array(roleGroups.length).fill(false)
+  );
+
+  const toggleDropDown = (index: number) => {
+    setOpenRoleStates((prev) =>
+      prev.map((state, i) => (i === index ? !state : state))
+    );
+  };
+
   return (
-    <div className="border m-4">
-      <button
-        className="w-80 h-16 py-4 px-6 grid grid-flow-col"
-        onClick={() => setOpenRole(!openRole)}
-      >
-        <span className="self-center justify-self-start text-xl">
-          {t(texts.roleDropDown)}{" "}
-        </span>
-        <img
-          className="w-6 h-6 self-center justify-self-end"
-          src={openRole ? ArrowUp : ArrowDown}
-          alt={
-            openRole ? t(texts.roleDropDownAltUp) : t(texts.roleDropDownAltDown)
-          }
-        />
-      </button>
-      {openRole && (
-        <div className="w-80">
-          {roleGroups?.map((roleGroup, index) => (
+    <div>
+      {roleGroups?.map((roleGroup, index) => (
+        <div key={index} className="border m-4">
+          <button
+            className="w-96 h-16 py-4 px-6 grid grid-flow-col"
+            onClick={() => toggleDropDown(index)}
+          >
+            <span className="self-center justify-self-start text-xl">
+              {roleGroup.name}{" "}
+            </span>
+            <img
+              className="w-6 h-6 self-center justify-self-end"
+              src={openRoleStates[index] ? ArrowUp : ArrowDown}
+              alt={openRoleStates[index] ? "Arrow Up" : "Arrow Down"}
+            />
+          </button>
+          {openRoleStates[index] && (
             <div key={index} className="m-4 mb-10">
-              <h3 className="text-base font-semibold">{roleGroup.name}</h3>
-              <div>
-                {roleGroup.roles?.map((role, index) => (
-                  <div key={index} className="flex flex-row mt-8 w-fit gap-6">
-                    <img
-                      src={urlFor(role.image?.asset?._ref ?? "")}
-                      alt={role.image?.alt ?? ""}
-                      className="w-36 h-36 object-cover"
-                    />
-                    <div>
-                      <h4 className="text-lg mb-2">{role.occupation}</h4>
-                      <h5 className="text-base mb-2">{role.name}</h5>
-                      <span>{role.text}</span>
-                    </div>
+              {roleGroup.roles?.map((role, roleIndex) => (
+                <div key={roleIndex} className="flex flex-row mt-8 gap-6">
+                  <img
+                    src={urlFor(role.image?.asset?._ref ?? "")}
+                    alt={role.image?.alt ?? ""}
+                    className="w-28 h-36 object-cover"
+                  />
+                  <div>
+                    <h4 className="text-2xl mb-2">{role.occupation}</h4>
+                    <h5 className="text-lg mb-2">{role.name}</h5>
+                    <span className="text-base">{role.text}</span>
                   </div>
-                ))}
-              </div>
+                </div>
+              ))}
             </div>
-          ))}
+          )}
         </div>
-      )}
+      ))}
     </div>
   );
 }

--- a/frontend/app/components/RoleDropDown.tsx
+++ b/frontend/app/components/RoleDropDown.tsx
@@ -8,6 +8,7 @@ import { createTexts, useTranslation } from "~/utils/i18n";
 import urlFor from "~/utils/imageUrlBuilder";
 import ArrowUp from "/arrow-up.svg";
 import ArrowDown from "/arrow-down.svg";
+import { motion } from "framer-motion";
 
 interface RoleDropDownProps {
   roleGroups: Array<{
@@ -37,11 +38,11 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
   const [openRoleStates, setOpenRoleStates] = useState(
     Array(roleGroups.length).fill(false)
   );
-
   const toggleDropDown = (index: number) => {
-    setOpenRoleStates((prev) =>
-      prev.map((state, i) => (i === index ? !state : state))
-    );
+    setOpenRoleStates((prev) => {
+      const newStates = prev.map((state, i) => (i === index ? !state : state));
+      return newStates;
+    });
   };
 
   return (
@@ -58,11 +59,25 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
             <img
               className="w-6 h-6 self-center justify-self-end"
               src={openRoleStates[index] ? ArrowUp : ArrowDown}
-              alt={openRoleStates[index] ? "Arrow Up" : "Arrow Down"}
+              alt={
+                openRoleStates[index]
+                  ? t(texts.roleDropDownAltUp)
+                  : t(texts.roleDropDownAltDown)
+              }
             />
           </button>
-          {openRoleStates[index] && (
-            <div key={index} className="m-4 mb-10">
+          <motion.div
+            key={index}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{
+              display: openRoleStates[index] ? "block" : "none",
+              height: openRoleStates[index] ? "auto" : 0,
+              opacity: openRoleStates[index] ? 1 : 0,
+            }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <div id={index.toString()} className="m-4 mb-10">
               {roleGroup.roles?.map((role, roleIndex) => (
                 <div key={roleIndex} className="flex flex-row mt-8 gap-6">
                   <img
@@ -78,7 +93,7 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
                 </div>
               ))}
             </div>
-          )}
+          </motion.div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Endringstype.
- Ny funksjonalitet.
- Refaktorering.

## Linke til oppgave (Notion).
[Lenek til Notion](https://www.notion.so/bekks/Oppdatere-RoleDropdown-79ca48ae01684325a5d5be545a3ceaf7?pvs=4)

## Beskrivelse.
RoleDropDown generer nå en knapp for hver Rolle type og animeres når den åpner. Mangler scrollIntoView da elementet ikke finnes når animasjonen starter.

## Skjermbilder.
![image](https://github.com/user-attachments/assets/298905e1-a3ad-4fc6-b02a-34df4fe046d4)

![image](https://github.com/user-attachments/assets/8538fc98-0fd9-48b5-8d37-1640a15f4973)
