### PR TITLE
Removed quoteblock from RichTextEditor

### DIFF
--- a/cms/schemaTypes/objects/RichTextEditor.ts
+++ b/cms/schemaTypes/objects/RichTextEditor.ts
@@ -7,10 +7,12 @@ export default {
       type: 'block',
       styles: [
         {title: 'Normal', value: 'normal'},
-        {title: 'h1', value: 'h1'},
-        {title: 'h2', value: 'h2'},
-        {title: 'h3', value: 'h3'},
-        {title: 'h4', value: 'h4'},
+        {title: 'Heading 1', value: 'h1'},
+        {title: 'Heading 2', value: 'h2'},
+        {title: 'Heading 3', value: 'h3'},
+        {title: 'Heading 4', value: 'h4'},
+        {title: 'Heading 5', value: 'h5'},
+        {title: 'Heading 6', value: 'h6'},
       ],
     },
     {

--- a/cms/schemaTypes/objects/RichTextEditor.ts
+++ b/cms/schemaTypes/objects/RichTextEditor.ts
@@ -5,6 +5,13 @@ export default {
   of: [
     {
       type: 'block',
+      styles: [
+        {title: 'Normal', value: 'normal'},
+        {title: 'h1', value: 'h1'},
+        {title: 'h2', value: 'h2'},
+        {title: 'h3', value: 'h3'},
+        {title: 'h4', value: 'h4'},
+      ],
     },
     {
       type: 'customImage',


### PR DESCRIPTION
## Endringstype.
- Refaktorering.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Fjerne-quoteblock-fra-RichTextEditor-62d7857dd6cb4396b713cd53aa795593?pvs=4)

## Beskrivelse.
Fjernet qutoeblock som tekstvalg fra RichTextEditor da dette erstattes av Sitat blokk.

## Skjermbilder.
<img width="214" alt="image" src="https://github.com/user-attachments/assets/9733d18c-5512-4d64-9a8b-906b96a4135a">

