### PR TITLE
fix-meta-title-frontpage

### DIFF
--- a/frontend/app/routes/($lang)._index.tsx
+++ b/frontend/app/routes/($lang)._index.tsx
@@ -34,13 +34,10 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   }
 
   return [
-    { title: data.event?.metaTitle ?? data.metaTitle ?? "Bruddet" },
+    { title: data.metaTitle ?? "Bruddet" },
     {
       property: "og:description",
-      content:
-        data.event?.metaDescription ??
-        data.metaDescription ??
-        "Hjemmesiden til bruddet i Grimstad",
+      content: data.metaDescription ?? "Hjemmesiden til Bruddet i Grimstad",
     },
   ];
 };
@@ -85,7 +82,6 @@ export default function Index() {
           />
 
           <div className="flex flex-row justify-center content-center  w-full mt-4">
-
             <Link to={params.lang == "en" ? "/en/info" : "/info"}>
               <button
                 className="text-white w-48  text-right px-4 py-2 rounded self-center font-serif text-2xl lg:text-4xl"


### PR DESCRIPTION
## Endringstype.
- Bugfix.

## Linke til oppgave (Notion).
https://www.notion.so/bekks/Endre-tittel-p-hovedsiden-fra-valgt-forestilling-til-Bruddet-2d4c70e6261c4928af69a5958c5fe6d6?pvs=4
## Beskrivelse.
Oppdaterte meta tittel på forsiden, slik at det alltid vil være default og ikke forestillingen sin tittel som brukes. 
## Skjermbilder.
![image](https://github.com/user-attachments/assets/3f2a4e70-ce0b-461c-8da7-739bbfe87be7)
