### PR TITLE
Fixed RoleDropdown going outside of viewport

### DIFF
--- a/frontend/app/components/RoleDropDown.tsx
+++ b/frontend/app/components/RoleDropDown.tsx
@@ -54,11 +54,14 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
   };
 
   return (
-    <div>
+    <>
       {roleGroups?.map((roleGroup, index) => (
-        <div key={index} className="border self-start m-4">
+        <div
+          key={index}
+          className="border self-start w-full min-w-52 max-w-96 my-4"
+        >
           <button
-            className="w-96 h-16 py-4 px-6 grid grid-flow-col"
+            className="w-full h-16 py-4 px-6 grid grid-flow-col"
             onClick={() => toggleDropDown(index)}
           >
             <span className="self-center justify-self-start text-xl">
@@ -104,7 +107,7 @@ export default function RoleDropDown({ roleGroups }: RoleDropDownProps) {
           </motion.div>
         </div>
       ))}
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Endringstype.
- Refaktorering.

## Linke til oppgave (Notion).
[Lenke til Notion](https://www.notion.so/bekks/Fikse-bredde-for-RoleDropDown-p-veldig-sm-skjermer-8d2c62b3c35646b993d6996bc0054817?pvs=4)

## Beskrivelse.
Fikset at RoleDropDown ikke tilpasset seg til skjermer mindre enn 384px, er nå min-width på 208px

## Skjermbilder.
<img width="726" alt="image" src="https://github.com/user-attachments/assets/0b8b28ad-ebbb-4f6c-b31d-75f0906da0a4">

<img width="611" alt="image" src="https://github.com/user-attachments/assets/39679c8f-9c8e-4e84-97bd-d5dd8cb96cda">
